### PR TITLE
feat: VP-gated comments UI with multi-chain SIWE support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,20 @@ VITE_BASE_RPC_URL=http://localhost:8545
 VITE_USE_TESTNET=false
 VITE_WALLETCONNECT_PROJECT_ID=dummy-project-id
 
+# Optional per-chain RPC overrides for the wagmi transports. Empty falls
+# through to viem's chain-default public RPC (fine for the connect-time
+# state reads we do; the SIWE-verify hot path runs on the mai-api side
+# with its own per-chain RPCs). Add overrides here if a chain's public
+# RPC rate-limits your dev/preview deploys. The chains below mirror
+# Snapshot's qidao.eth voting matrix (https://snapshot.box/#/s:qidao.eth)
+# so any wallet that can vote on a proposal can sign in here.
+VITE_BASE_SEPOLIA_RPC_URL=
+VITE_MAINNET_RPC_URL=
+VITE_OPTIMISM_RPC_URL=
+VITE_GNOSIS_RPC_URL=
+VITE_POLYGON_RPC_URL=
+VITE_ARBITRUM_RPC_URL=
+
 # IPFS Configuration (Mai API is primary method)
 VITE_USE_MAI_API=true
 VITE_IPFS_API_URL=http://localhost:3001/v2/ipfs-upload

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "qips",
@@ -39,6 +40,7 @@
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "siwe": "^3.0.0",
         "sonner": "^2.0.7",
         "swr": "^2.2.4",
         "tailwind-merge": "^3.3.1",
@@ -513,6 +515,16 @@
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
 
+    "@spruceid/siwe-parser": ["@spruceid/siwe-parser@3.0.0", "", { "dependencies": { "@noble/hashes": "^1.1.2", "apg-js": "^4.4.0" } }, "sha512-Y92k63ilw/8jH9Ry4G2e7lQd0jZAvb0d/Q7ssSD0D9mp/Zt2aCXIc3g0ny9yhplpAx1QXHsMz/JJptHK/zDGdw=="],
+
+    "@stablelib/binary": ["@stablelib/binary@1.0.1", "", { "dependencies": { "@stablelib/int": "^1.0.1" } }, "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q=="],
+
+    "@stablelib/int": ["@stablelib/int@1.0.1", "", {}, "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="],
+
+    "@stablelib/random": ["@stablelib/random@1.0.2", "", { "dependencies": { "@stablelib/binary": "^1.0.1", "@stablelib/wipe": "^1.0.1" } }, "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w=="],
+
+    "@stablelib/wipe": ["@stablelib/wipe@1.0.1", "", {}, "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.1.13", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.5.1", "lightningcss": "1.30.1", "magic-string": "^0.30.18", "source-map-js": "^1.2.1", "tailwindcss": "4.1.13" } }, "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.13", "", { "dependencies": { "detect-libc": "^2.0.4", "tar": "^7.4.3" }, "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.13", "@tailwindcss/oxide-darwin-arm64": "4.1.13", "@tailwindcss/oxide-darwin-x64": "4.1.13", "@tailwindcss/oxide-freebsd-x64": "4.1.13", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.13", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.13", "@tailwindcss/oxide-linux-arm64-musl": "4.1.13", "@tailwindcss/oxide-linux-x64-gnu": "4.1.13", "@tailwindcss/oxide-linux-x64-musl": "4.1.13", "@tailwindcss/oxide-wasm32-wasi": "4.1.13", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.13", "@tailwindcss/oxide-win32-x64-msvc": "4.1.13" } }, "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA=="],
@@ -684,6 +696,8 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "apg-js": ["apg-js@4.4.0", "", {}, "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
@@ -1554,6 +1568,8 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "siwe": ["siwe@3.0.0", "", { "dependencies": { "@spruceid/siwe-parser": "^3.0.0", "@stablelib/random": "^1.0.1" }, "peerDependencies": { "ethers": "^5.6.8 || ^6.0.8" } }, "sha512-P2/ry7dHYJA6JJ5+veS//Gn2XDwNb3JMvuD6xiXX8L/PJ1SNVD4a3a8xqEbmANx+7kNQcD8YAh1B9bNKKvRy/g=="],
 
     "socket.io-client": ["socket.io-client@4.7.1", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.3.2", "engine.io-client": "~6.5.1", "socket.io-parser": "~4.2.4" } }, "sha512-Qk3Xj8ekbnzKu3faejo4wk2MzXA029XppiXtTF/PkbTg+fcwaTw1PlDrTrrrU4mKoYC4dvlApOnSeyLCKwek2w=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "siwe": "^3.0.0",
     "sonner": "^2.0.7",
     "swr": "^2.2.4",
     "tailwind-merge": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Tekrajs & Publu",
   "keywords": [],
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host ${HOST:-127.0.0.1} --port ${PORT:-3000}",
     "dev:local": "./scripts/start-pure-local.sh",
     "dev:local:migrate": "./scripts/start-pure-local.sh --migrate",
     "dev:api": "./scripts/start-api-mode.sh",

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,4 @@
+{
+  "name": "qips.qidao",
+  "script": "dev"
+}

--- a/src/components/Comments/CommentComposer.tsx
+++ b/src/components/Comments/CommentComposer.tsx
@@ -63,7 +63,7 @@ export const CommentComposer: React.FC<CommentComposerProps> = ({ qciId }) => {
         break;
       case 403:
         toast.error(
-          `You need ${formatNumber(result.threshold)} qipowah to comment. ` +
+          `You need ${formatNumber(result.threshold)} aveQi to comment. ` +
             `You have ${formatNumber(result.currentVp)}.`,
         );
         break;

--- a/src/components/Comments/CommentComposer.tsx
+++ b/src/components/Comments/CommentComposer.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { config } from '@/config/env';
+import { useComments } from '@/hooks/useComments';
+import { useSiweSession } from '@/hooks/useSiweSession';
+
+interface CommentComposerProps {
+  qciId: number;
+}
+
+const WARNING_RATIO = 0.8;
+
+const ENCODER = new TextEncoder();
+function utf8ByteLength(s: string): number {
+  return ENCODER.encode(s).length;
+}
+
+function formatNumber(s: string): string {
+  // The API returns vp/threshold as decimal strings; render with thousand
+  // separators when the integer part is large, leave the fractional part
+  // untouched.
+  if (!/^-?\d+(\.\d+)?$/.test(s)) return s;
+  const [intPart, fracPart] = s.split('.');
+  const formatted = Number(intPart).toLocaleString();
+  return fracPart ? `${formatted}.${fracPart}` : formatted;
+}
+
+/**
+ * Gated comment composer. Lives below CommentList; only renders when the
+ * caller has confirmed the user has an authenticated session — see
+ * <Comments> for the wiring.
+ */
+export const CommentComposer: React.FC<CommentComposerProps> = ({ qciId }) => {
+  const [body, setBody] = useState('');
+  const { postComment, isPosting } = useComments(qciId);
+  const { sessionToken, clearOn401 } = useSiweSession();
+
+  const maxBytes = config.qipCommentsBodyMaxBytes;
+  const byteLength = useMemo(() => utf8ByteLength(body), [body]);
+  const overLimit = byteLength > maxBytes;
+  const nearLimit = !overLimit && byteLength >= Math.floor(maxBytes * WARNING_RATIO);
+  const trimmedEmpty = body.trim().length === 0;
+  const submitDisabled = isPosting || trimmedEmpty || overLimit;
+
+  const handleSubmit = async () => {
+    if (submitDisabled) return;
+
+    const result = await postComment({ body, sessionToken });
+
+    if (result.ok) {
+      setBody('');
+      toast.success('Comment posted.');
+      return;
+    }
+
+    // Failure paths — keep the textarea so the user can edit and retry.
+    switch (result.status) {
+      case 401:
+        clearOn401();
+        toast.error('Your session expired. Please sign in again.');
+        break;
+      case 403:
+        toast.error(
+          `You need ${formatNumber(result.threshold)} qipowah to comment. ` +
+            `You have ${formatNumber(result.currentVp)}.`,
+        );
+        break;
+      case 413:
+        toast.error(`Comment too long. Maximum is ${result.maxBytes.toLocaleString()} bytes.`);
+        break;
+      case 429:
+        toast.error("You're posting too fast. Please try again in a minute.");
+        break;
+      case 503:
+        toast.error('Vote-power service is unavailable right now. Please try again shortly.');
+        break;
+      default:
+        toast.error(`Couldn't post comment: ${result.error}`);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Share your thoughts on this proposal…"
+        rows={4}
+        className="min-h-[100px]"
+        disabled={isPosting}
+      />
+      <div className="flex items-center justify-between text-xs">
+        <span
+          className={
+            overLimit
+              ? 'text-destructive'
+              : nearLimit
+                ? 'text-amber-600 dark:text-amber-400'
+                : 'text-muted-foreground'
+          }
+          aria-live="polite"
+        >
+          {byteLength.toLocaleString()} / {maxBytes.toLocaleString()} bytes
+          {overLimit && ' — too long'}
+        </span>
+        <Button onClick={handleSubmit} disabled={submitDisabled} size="sm">
+          {isPosting ? 'Posting…' : 'Post'}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Comments/CommentList.tsx
+++ b/src/components/Comments/CommentList.tsx
@@ -64,7 +64,7 @@ export const CommentList: React.FC<CommentListProps> = ({ qciId }) => {
   if (comments.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
-        No comments yet. Voters with sufficient qipowah can post.
+        No comments yet. Voters with sufficient aveQi can post.
       </p>
     );
   }

--- a/src/components/Comments/CommentList.tsx
+++ b/src/components/Comments/CommentList.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useRef } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { useComments } from '@/hooks/useComments';
+import { useIsEditor } from '@/hooks/useIsEditor';
+import { useSiweSession } from '@/hooks/useSiweSession';
+import type { Comment } from '@/types/comments';
+import { Skeleton } from './CommentSkeleton';
+import { SafeMarkdown } from './SafeMarkdown';
+import { ModerationMenu } from './ModerationMenu';
+
+interface CommentListProps {
+  qciId: number;
+}
+
+const SHORTEN_LEAD = 6;
+const SHORTEN_TAIL = 4;
+
+function shortenAddress(addr: string): string {
+  if (!addr.startsWith('0x') || addr.length < SHORTEN_LEAD + SHORTEN_TAIL + 2) return addr;
+  return `${addr.slice(0, SHORTEN_LEAD)}…${addr.slice(-SHORTEN_TAIL)}`;
+}
+
+export const CommentList: React.FC<CommentListProps> = ({ qciId }) => {
+  const { comments, isLoading, isError, hasMore, isFetchingMore, fetchMore } = useComments(qciId);
+  const { isEditor } = useIsEditor();
+  const { sessionToken } = useSiweSession();
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Infinite scroll: when the sentinel below the last row enters the viewport,
+  // ask the query for the next page. We disable the observer while a fetch
+  // is already in flight so we don't queue duplicate page requests.
+  useEffect(() => {
+    if (!hasMore || isFetchingMore) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) fetchMore();
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasMore, isFetchingMore, fetchMore]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" aria-busy="true">
+        <Skeleton />
+        <Skeleton />
+        <Skeleton />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">
+        Couldn't load comments. Try refreshing the page.
+      </p>
+    );
+  }
+
+  if (comments.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No comments yet. Voters with sufficient qipowah can post.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {comments.map((c) => (
+        <CommentRow
+          key={c.id}
+          comment={c}
+          qciId={qciId}
+          showModeration={isEditor}
+          sessionToken={sessionToken}
+        />
+      ))}
+
+      {/* Sentinel for infinite-scroll. */}
+      {hasMore && <div ref={sentinelRef} aria-hidden="true" />}
+
+      {isFetchingMore && (
+        <div className="text-center text-sm text-muted-foreground">Loading more…</div>
+      )}
+    </div>
+  );
+};
+
+interface CommentRowProps {
+  comment: Comment;
+  qciId: number;
+  showModeration: boolean;
+  sessionToken?: string;
+}
+
+const CommentRow: React.FC<CommentRowProps> = ({
+  comment,
+  qciId,
+  showModeration,
+  sessionToken,
+}) => {
+  const display = comment.ensName ?? shortenAddress(comment.author);
+  const timestamp = formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true });
+
+  return (
+    <div className="flex gap-3 border-b border-border/40 pb-6 last:border-0">
+      <div
+        className="h-8 w-8 shrink-0 rounded-full bg-muted"
+        aria-hidden="true"
+        // Trivial deterministic-color placeholder. Real avatar render (Boring
+        // Avatars / blockies) is a follow-up; keeping it minimal here so we
+        // don't pull a new dependency just for this PR.
+        style={{ background: `hsl(${hashHue(comment.author)} 60% 45%)` }}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="font-medium text-foreground">{display}</span>
+          <span className="text-xs text-muted-foreground">{timestamp}</span>
+          {showModeration && (
+            <div className="ml-auto">
+              <ModerationMenu
+                qciId={qciId}
+                commentId={comment.id}
+                isHidden={Boolean(comment.hiddenAt)}
+                sessionToken={sessionToken}
+              />
+            </div>
+          )}
+        </div>
+        <SafeMarkdown body={comment.body} className="prose prose-sm dark:prose-invert mt-1 max-w-none" />
+      </div>
+    </div>
+  );
+};
+
+function hashHue(addr: string): number {
+  let h = 0;
+  for (let i = 0; i < addr.length; i++) {
+    h = (h * 31 + addr.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % 360;
+}

--- a/src/components/Comments/CommentSkeleton.tsx
+++ b/src/components/Comments/CommentSkeleton.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/** Minimal skeleton row used while a comment list is loading. */
+export const Skeleton: React.FC = () => (
+  <div className="flex gap-3 border-b border-border/40 pb-6 last:border-0">
+    <div className="h-8 w-8 shrink-0 animate-pulse rounded-full bg-muted" />
+    <div className="flex-1 space-y-2">
+      <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+      <div className="h-3 w-full animate-pulse rounded bg-muted" />
+      <div className="h-3 w-4/5 animate-pulse rounded bg-muted" />
+    </div>
+  </div>
+);

--- a/src/components/Comments/ModerationMenu.tsx
+++ b/src/components/Comments/ModerationMenu.tsx
@@ -1,0 +1,192 @@
+import React, { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { MoreHorizontal } from 'lucide-react';
+import { toast } from 'sonner';
+import { config } from '@/config/env';
+import { getMaiAPIClient } from '@/services/maiApiClient';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { queryKeyPatterns, queryKeys } from '@/utils/queryKeys';
+
+interface ModerationMenuProps {
+  qciId: number;
+  commentId: number;
+  isHidden: boolean;
+  sessionToken?: string;
+}
+
+/**
+ * Editor-only menu attached to each rendered comment. The visual gate (only
+ * rendered when useIsEditor() returns true) is polish; the API enforces
+ * authorization independently — the moderation routes call hasRole()
+ * server-side before applying any change.
+ *
+ * Hide flow uses optimistic UI: the row is removed from the list cache as
+ * soon as the user confirms, then we invalidate after the mutation resolves
+ * to pick up the API's authoritative state. On error we re-invalidate so
+ * the row reappears.
+ */
+export const ModerationMenu: React.FC<ModerationMenuProps> = ({
+  qciId,
+  commentId,
+  isHidden,
+  sessionToken,
+}) => {
+  const queryClient = useQueryClient();
+  const client = getMaiAPIClient(config.maiApiUrl);
+  const [hideDialogOpen, setHideDialogOpen] = useState(false);
+  const [reason, setReason] = useState('');
+
+  const hideMutation = useMutation({
+    mutationFn: async () => {
+      const result = await client.hideQipComment({
+        commentId,
+        reason: reason.trim() || undefined,
+        sessionToken,
+      });
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      return result;
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.qipComments(qciId) });
+      const previous = queryClient.getQueryData(queryKeys.qipComments(qciId));
+      // Optimistically remove the row from every loaded page.
+      queryClient.setQueryData(
+        queryKeys.qipComments(qciId),
+        (old: { pages?: Array<{ comments: Array<{ id: number }> }> } | undefined) => {
+          if (!old?.pages) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              comments: page.comments.filter((c) => c.id !== commentId),
+            })),
+          };
+        },
+      );
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous !== undefined) {
+        queryClient.setQueryData(queryKeys.qipComments(qciId), ctx.previous);
+      }
+      toast.error(`Failed to hide comment: ${err instanceof Error ? err.message : 'unknown'}`);
+    },
+    onSuccess: () => {
+      toast.success('Comment hidden');
+      setHideDialogOpen(false);
+      setReason('');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeyPatterns.allQipComments });
+    },
+  });
+
+  const unhideMutation = useMutation({
+    mutationFn: async () => {
+      const result = await client.unhideQipComment({ commentId, sessionToken });
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      return result;
+    },
+    onSuccess: () => {
+      toast.success('Comment restored');
+    },
+    onError: (err) => {
+      toast.error(`Failed to unhide comment: ${err instanceof Error ? err.message : 'unknown'}`);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeyPatterns.allQipComments });
+    },
+  });
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-foreground"
+            aria-label="Moderation menu"
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {isHidden ? (
+            <DropdownMenuItem
+              onSelect={() => unhideMutation.mutate()}
+              disabled={unhideMutation.isPending}
+            >
+              Restore comment
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem onSelect={() => setHideDialogOpen(true)}>
+              Hide comment
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={hideDialogOpen} onOpenChange={setHideDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Hide this comment?</DialogTitle>
+            <DialogDescription>
+              The comment is removed from the public view but kept in the audit log. You can
+              restore it from the same menu.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <label htmlFor="hide-reason" className="text-sm text-muted-foreground">
+              Reason (optional)
+            </label>
+            <Input
+              id="hide-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Spam, off-topic, ..."
+              maxLength={500}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setHideDialogOpen(false);
+                setReason('');
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => hideMutation.mutate()}
+              disabled={hideMutation.isPending}
+            >
+              {hideMutation.isPending ? 'Hiding...' : 'Hide'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/Comments/SafeMarkdown.tsx
+++ b/src/components/Comments/SafeMarkdown.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import type { Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+const ALLOWED_PROTOCOLS = /^(https?:|mailto:)/i;
+
+/**
+ * Renders a comment body. Inputs are untrusted user-generated markdown — even
+ * comments from high-VP wallets are UGC. Defenses, in layers:
+ *
+ *   1. react-markdown 10 disables raw HTML by default. We do not pass
+ *      `rehype-raw` or any equivalent, so `<img onerror=...>` and the like
+ *      come through as plain text.
+ *
+ *   2. urlTransform restricts link/image URL protocols to http(s) and
+ *      mailto. Anything else (`javascript:`, `data:`, `ipfs:`, `vbscript:`,
+ *      etc.) returns undefined, which makes react-markdown render the link
+ *      text as plain text — there is no <a> element produced.
+ *
+ *   3. The custom <a> renderer always emits `target="_blank"` and
+ *      `rel="noopener noreferrer nofollow"` so even allow-listed protocols
+ *      cannot perform tab-nabbing or pass referrer credit.
+ *
+ *   4. The custom <img> renderer returns null. Inline images would let an
+ *      attacker beacon to arbitrary servers via redirect chains starting
+ *      from an http(s) URL the protocol allowlist accepts. Stripping them
+ *      is simpler than verifying every redirect target.
+ */
+const COMPONENTS: Components = {
+  a({ href, children, ...rest }) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        {...rest}
+      >
+        {children}
+      </a>
+    );
+  },
+  // Strip images entirely.
+  img() {
+    return null;
+  },
+};
+
+interface SafeMarkdownProps {
+  body: string;
+  className?: string;
+}
+
+export const SafeMarkdown: React.FC<SafeMarkdownProps> = ({ body, className }) => {
+  return (
+    <div className={className ?? 'prose prose-sm dark:prose-invert max-w-none'}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        urlTransform={(url) => (ALLOWED_PROTOCOLS.test(url) ? url : '')}
+        components={COMPONENTS}
+      >
+        {body}
+      </ReactMarkdown>
+    </div>
+  );
+};

--- a/src/components/Comments/SiweLoginButton.tsx
+++ b/src/components/Comments/SiweLoginButton.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ConnectKitButton } from 'connectkit';
+import { useAccount } from 'wagmi';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { useSiweSession } from '@/hooks/useSiweSession';
+
+/**
+ * The auth gate above the comment composer:
+ *
+ *   no wallet           → ConnectKitButton (defers to the existing flow
+ *                          configured in Web3Provider — keeps wallet UX
+ *                          consistent across the app).
+ *   wallet, no session  → "Sign in to comment" button → useSiweSession.signIn()
+ *   wallet + session    → renders nothing (composer takes over).
+ *
+ * Sign-in errors map to silent / toast surfaces:
+ *   user_rejected → silent (the user just cancelled the wallet popup)
+ *   verify_failed → toast (the API rejected the SIWE message)
+ *   unknown       → toast (transport error, etc.)
+ */
+export const SiweLoginButton: React.FC = () => {
+  const { isConnected } = useAccount();
+  const { sessionToken, signIn, isPending } = useSiweSession();
+
+  if (sessionToken) {
+    return null;
+  }
+
+  if (!isConnected) {
+    return <ConnectKitButton />;
+  }
+
+  return (
+    <Button
+      onClick={async () => {
+        const result = await signIn();
+        if (!result.ok && result.reason !== 'user_rejected') {
+          toast.error(
+            result.reason === 'verify_failed'
+              ? "Couldn't verify your signature. Please try again."
+              : "Couldn't sign in. Please try again.",
+          );
+        }
+      }}
+      disabled={isPending}
+    >
+      {isPending ? 'Signing in…' : 'Sign in to comment'}
+    </Button>
+  );
+};

--- a/src/components/Comments/SiweLoginButton.tsx
+++ b/src/components/Comments/SiweLoginButton.tsx
@@ -1,9 +1,23 @@
 import React from 'react';
 import { ConnectKitButton } from 'connectkit';
-import { useAccount } from 'wagmi';
+import { useAccount, useChainId } from 'wagmi';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { useSiweSession } from '@/hooks/useSiweSession';
+import { useSafeDeployments, pickSiweChainId } from '@/hooks/useSafeDeployments';
+
+// Minimal chain-id → human label map for the wrong-chain toast.
+// Mirrors the chains the Safe-deployment probe checks (mainnet, polygon,
+// base, linea); add entries here if useSafeDeployments grows its allowlist.
+const CHAIN_LABELS: Record<number, string> = {
+  1: 'Ethereum',
+  137: 'Polygon',
+  8453: 'Base',
+  59144: 'Linea',
+};
+
+const chainLabel = (chainId: number): string =>
+  CHAIN_LABELS[chainId] ?? `chain ${chainId}`;
 
 /**
  * The auth gate above the comment composer:
@@ -20,7 +34,9 @@ import { useSiweSession } from '@/hooks/useSiweSession';
  *   unknown       → toast (transport error, etc.)
  */
 export const SiweLoginButton: React.FC = () => {
-  const { isConnected } = useAccount();
+  const { address, isConnected } = useAccount();
+  const walletChainId = useChainId();
+  const { data: safeDeployments } = useSafeDeployments(address);
   const { sessionToken, signIn, isPending } = useSiweSession();
 
   if (sessionToken) {
@@ -35,13 +51,21 @@ export const SiweLoginButton: React.FC = () => {
     <Button
       onClick={async () => {
         const result = await signIn();
-        if (!result.ok && result.reason !== 'user_rejected') {
+        if (result.ok || result.reason === 'user_rejected') return;
+
+        if (result.reason === 'wrong_chain') {
+          const targetChainId = pickSiweChainId(walletChainId, safeDeployments);
           toast.error(
-            result.reason === 'verify_failed'
-              ? "Couldn't verify your signature. Please try again."
-              : "Couldn't sign in. Please try again.",
+            `Switch your wallet to ${chainLabel(targetChainId)} to sign in — your Safe is deployed there.`,
           );
+          return;
         }
+
+        toast.error(
+          result.reason === 'verify_failed'
+            ? "Couldn't verify your signature. Please try again."
+            : "Couldn't sign in. Please try again.",
+        );
       }}
       disabled={isPending}
     >

--- a/src/components/Comments/SiweLoginButton.tsx
+++ b/src/components/Comments/SiweLoginButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ConnectKitButton } from 'connectkit';
 import { useAccount, useChainId } from 'wagmi';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -22,9 +21,10 @@ const chainLabel = (chainId: number): string =>
 /**
  * The auth gate above the comment composer:
  *
- *   no wallet           → ConnectKitButton (defers to the existing flow
- *                          configured in Web3Provider — keeps wallet UX
- *                          consistent across the app).
+ *   no wallet           → small hint pointing the user at the header connect
+ *                          button (no second wallet button — the header
+ *                          already owns connect UX, and rendering another
+ *                          one inline is visually redundant).
  *   wallet, no session  → "Sign in to comment" button → useSiweSession.signIn()
  *   wallet + session    → renders nothing (composer takes over).
  *
@@ -44,7 +44,11 @@ export const SiweLoginButton: React.FC = () => {
   }
 
   if (!isConnected) {
-    return <ConnectKitButton />;
+    return (
+      <p className="text-sm text-muted-foreground">
+        Connect your wallet from the top right to comment.
+      </p>
+    );
   }
 
   return (

--- a/src/components/Comments/index.tsx
+++ b/src/components/Comments/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { CommentComposer } from './CommentComposer';
+import { CommentList } from './CommentList';
+import { SiweLoginButton } from './SiweLoginButton';
+import { useSiweSession } from '@/hooks/useSiweSession';
+
+interface CommentsProps {
+  qciId: number;
+}
+
+/**
+ * Top-level comment surface for a QIP detail page.
+ *
+ * Read path is unconditional — the comment list renders even without a
+ * connected wallet. Write path is gated by SIWE: if the user has no session,
+ * SiweLoginButton handles connect + sign-in; once authenticated, the
+ * composer takes over.
+ *
+ * Caller should mount this with a qciId-keyed parent (or trust the natural
+ * unmount/mount when the route's qciId param changes) so navigating between
+ * QCIs resets the comment tree cleanly.
+ */
+export const Comments: React.FC<CommentsProps> = ({ qciId }) => {
+  const { sessionToken } = useSiweSession();
+
+  return (
+    <section
+      aria-label="Comments"
+      className="mt-8 border-t border-border pt-6"
+      key={qciId}
+    >
+      <h2 className="mb-4 text-lg font-semibold text-foreground">Discussion</h2>
+
+      <CommentList qciId={qciId} />
+
+      <div className="mt-6">
+        {sessionToken ? <CommentComposer qciId={qciId} /> : <SiweLoginButton />}
+      </div>
+    </section>
+  );
+};
+
+export default Comments;

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -1,5 +1,20 @@
-import { base, baseSepolia, mainnet } from 'wagmi/chains'
+import { arbitrum, base, baseSepolia, gnosis, mainnet, optimism, polygon } from 'wagmi/chains'
 import { config } from './env'
+
+/**
+ * Supported chains mirror the matrix Snapshot accepts for `qidao.eth` voting,
+ * so any wallet that can vote on a Snapshot proposal can sign in to the
+ * QIPs comments feature with the same key — including Safes whose contract
+ * code lives on a non-Base chain (Polygon, Optimism, Gnosis, Arbitrum, …).
+ *
+ * Source of truth: https://snapshot.box/#/s:qidao.eth — when Snapshot adds
+ * or drops a chain for the qidao.eth space, mirror the change here.
+ *
+ * Note: this list governs which chains the wallet may be on at sign-in.
+ * The QCI Registry contract still lives on Base; `getDefaultChainId()`
+ * keeps Base as the initial chain so non-comments routes (registry reads,
+ * status reads) keep working without an explicit network switch.
+ */
 
 /**
  * Local Base fork configuration for development
@@ -16,31 +31,40 @@ export const localBaseFork = {
 }
 
 /**
- * Get chains configuration based on environment
+ * Get chains configuration based on environment.
+ *
+ * Production includes the full Snapshot `qidao.eth` matrix so cross-chain
+ * Safes can connect without ConnectKit's "Wrong network" guard rejecting
+ * them. Testnet adds `baseSepolia` first so dev wallets default to it.
  */
 export const getChains = () => {
   if (config.isDevelopment) {
-    return [localBaseFork, base, baseSepolia, mainnet]
+    return [localBaseFork, base, baseSepolia, mainnet, optimism, gnosis, polygon, arbitrum]
   }
-  
+
   if (config.useTestnet) {
-    return [baseSepolia, base, mainnet]
+    return [baseSepolia, base, mainnet, optimism, gnosis, polygon, arbitrum]
   }
-  
-  return [base, mainnet]
+
+  return [mainnet, optimism, gnosis, polygon, base, arbitrum]
 }
 
 /**
- * Get default chain ID based on environment
+ * Get default chain ID based on environment.
+ *
+ * Stays Base because the rest of the app reads the QCI Registry (on Base);
+ * the comments path does not require Base — the SIWE flow embeds whichever
+ * chain the wallet is actually on, so a Polygon Safe signs on Polygon and
+ * verification picks the right RPC server-side.
  */
 export const getDefaultChainId = () => {
   if (config.isDevelopment && config.localMode) {
     return localBaseFork.id
   }
-  
+
   if (config.useTestnet) {
     return baseSepolia.id
   }
-  
+
   return base.id
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -58,6 +58,11 @@ export const config = {
   // Mai API Configuration for QCI fetching
   maiApiUrl: getEnvVar("VITE_MAI_API_URL", "https://api.mai.finance"),
 
+  // QIP comments body byte cap; must agree with the API's
+  // QIP_COMMENTS_BODY_MAX_BYTES so the client-side counter and the server-side
+  // cap reject the same inputs. Default 8192 (8 KB).
+  qipCommentsBodyMaxBytes: parseInt(getEnvVar("VITE_QIP_COMMENTS_BODY_MAX_BYTES", "8192"), 10) || 8192,
+
   // App Configuration
   localMode: getBoolEnvVar("VITE_LOCAL_MODE", false),
   useTestnet: getBoolEnvVar("VITE_USE_TESTNET", false),

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,3 +9,7 @@ export { useQCIVersionHistory } from './useQCIVersionHistory';
 // QIP comments
 export { useSiweSession } from './useSiweSession';
 export type { SiweSessionStatus, SiweSignInError, UseSiweSessionResult } from './useSiweSession';
+export { useComments } from './useComments';
+export type { UseCommentsResult } from './useComments';
+export { useIsEditor } from './useIsEditor';
+export type { UseIsEditorResult } from './useIsEditor';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,7 @@ export { useQCIList } from './useQCIList';
 export { useCreateQCI } from './useCreateQCI';
 export { useUpdateQCI } from './useUpdateQCI';
 export { useQCIVersionHistory } from './useQCIVersionHistory';
+
+// QIP comments
+export { useSiweSession } from './useSiweSession';
+export type { SiweSessionStatus, SiweSignInError, UseSiweSessionResult } from './useSiweSession';

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -1,0 +1,104 @@
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { config } from '../config/env';
+import { getMaiAPIClient } from '../services/maiApiClient';
+import type {
+  Comment,
+  CommentListResponse,
+  PostCommentResponse,
+} from '../types/comments';
+import { queryKeys } from '../utils/queryKeys';
+
+const PAGE_SIZE = 50;
+const STALE_TIME_MS = 30_000;
+
+interface PostCommentArgs {
+  body: string;
+  /**
+   * Optional bearer token. When omitted, the same-origin HttpOnly cookie
+   * authenticates the request (cross-origin deployments must pass the token).
+   */
+  sessionToken?: string;
+}
+
+export interface UseCommentsResult {
+  /** Flattened newest-first list across every loaded page. */
+  comments: Comment[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  error: Error | null;
+
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  fetchMore: () => void;
+
+  /**
+   * Post a comment. Returns the discriminated API result so callers can
+   * branch on `result.ok` and `result.status` (the 403 path carries the
+   * server-supplied threshold and currentVp values).
+   */
+  postComment: (args: PostCommentArgs) => Promise<PostCommentResponse>;
+  isPosting: boolean;
+}
+
+/**
+ * Cursor-paginated comment list for a single QCI, keyed on qciId.
+ *
+ * Anonymous reads work without a wallet — the comment list is publicly
+ * visible. Hidden comments are filtered server-side and never appear in
+ * any page.
+ */
+export function useComments(qciId: number): UseCommentsResult {
+  const queryClient = useQueryClient();
+  const client = getMaiAPIClient(config.maiApiUrl);
+
+  const query = useInfiniteQuery<CommentListResponse, Error>({
+    queryKey: queryKeys.qipComments(qciId),
+    initialPageParam: undefined,
+    queryFn: async ({ pageParam }) =>
+      client.listQipComments({
+        qciId,
+        limit: PAGE_SIZE,
+        before: typeof pageParam === 'number' ? pageParam : undefined,
+      }),
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
+    staleTime: STALE_TIME_MS,
+    refetchOnWindowFocus: false,
+    enabled: Number.isInteger(qciId) && qciId >= 0,
+  });
+
+  const mutation = useMutation<PostCommentResponse, Error, PostCommentArgs>({
+    mutationFn: async ({ body, sessionToken }) =>
+      client.postQipComment({ qciId, body, sessionToken }),
+    onSuccess: (result) => {
+      // Only invalidate on a real insert. A 403 / 401 / 413 / etc. is a
+      // structured rejection — there's no new row to fold into the list.
+      if (result.ok) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.qipComments(qciId),
+        });
+      }
+    },
+  });
+
+  return {
+    comments: query.data?.pages.flatMap((p) => p.comments) ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    error: query.error,
+    hasMore: Boolean(query.hasNextPage),
+    isFetchingMore: query.isFetchingNextPage,
+    fetchMore: () => {
+      if (query.hasNextPage && !query.isFetchingNextPage) {
+        void query.fetchNextPage();
+      }
+    },
+    postComment: mutation.mutateAsync,
+    isPosting: mutation.isPending,
+  };
+}

--- a/src/hooks/useIsEditor.ts
+++ b/src/hooks/useIsEditor.ts
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAccount, usePublicClient } from 'wagmi';
+import { base } from 'wagmi/chains';
+import { config } from '../config/env';
+import { QCIRegistryABI } from '../config/abis/QCIRegistry';
+
+const EDITOR_ROLE_TTL_MS = Infinity; // EDITOR_ROLE bytes32 hash is a contract constant
+const HAS_ROLE_TTL_MS = 60_000; // mirrors mai-api lib/editorRole.ts cache window
+
+export interface UseIsEditorResult {
+  isEditor: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * Returns whether the connected wallet holds EDITOR_ROLE on the QCIRegistry.
+ *
+ * The result drives moderation-menu visibility on the comments UI; the API
+ * gates the actual moderation action separately, so a UI-only bypass cannot
+ * grant moderation power. Returns `{ isEditor: false }` when no wallet is
+ * connected.
+ */
+export function useIsEditor(): UseIsEditorResult {
+  const { address } = useAccount();
+  const publicClient = usePublicClient({ chainId: base.id });
+  const registryAddress = config.registryAddress;
+
+  // Step 1: read the EDITOR_ROLE bytes32 hash. It's a contract constant, so
+  // we cache it forever per registry address.
+  const editorRoleQuery = useQuery({
+    queryKey: ['qip-comments', 'editor-role-hash', registryAddress],
+    enabled: Boolean(publicClient && registryAddress),
+    staleTime: EDITOR_ROLE_TTL_MS,
+    gcTime: EDITOR_ROLE_TTL_MS,
+    queryFn: async () => {
+      if (!publicClient) throw new Error('public client unavailable');
+      const hash = (await publicClient.readContract({
+        address: registryAddress,
+        abi: QCIRegistryABI,
+        functionName: 'EDITOR_ROLE',
+      })) as `0x${string}`;
+      return hash;
+    },
+  });
+
+  // Step 2: read hasRole(EDITOR_ROLE, address). Re-checked every 60 seconds
+  // so a freshly granted role takes effect promptly. Refresh on focus is
+  // disabled so toggling tabs doesn't burn RPC calls.
+  const hasRoleQuery = useQuery({
+    queryKey: ['qip-comments', 'is-editor', registryAddress, address?.toLowerCase()],
+    enabled: Boolean(publicClient && registryAddress && address && editorRoleQuery.data),
+    staleTime: HAS_ROLE_TTL_MS,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      if (!publicClient || !address || !editorRoleQuery.data) return false;
+      const result = (await publicClient.readContract({
+        address: registryAddress,
+        abi: QCIRegistryABI,
+        functionName: 'hasRole',
+        args: [editorRoleQuery.data, address],
+      })) as boolean;
+      return result;
+    },
+  });
+
+  return {
+    isEditor: hasRoleQuery.data === true,
+    isLoading: editorRoleQuery.isLoading || hasRoleQuery.isLoading,
+  };
+}

--- a/src/hooks/useSafeDeployments.ts
+++ b/src/hooks/useSafeDeployments.ts
@@ -45,13 +45,11 @@ const SAFE_TX_SERVICE_HOSTS: Readonly<Record<number, string>> = {
 };
 
 const PROBE_TIMEOUT_MS = 6000;
+const PROBE_RETRY_DELAYS_MS = [1000, 3000] as const;
 
-async function probeOne(
-  chainId: number,
-  host: string,
-  address: string,
-): Promise<'deployed' | 'not_deployed' | 'unknown'> {
-  const url = `https://${host}/api/v1/safes/${address}/`;
+async function fetchOne(
+  url: string,
+): Promise<'deployed' | 'not_deployed' | 'rate_limited' | 'unknown'> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
   try {
@@ -62,13 +60,42 @@ async function probeOne(
     });
     if (res.status === 200) return 'deployed';
     if (res.status === 404) return 'not_deployed';
-    // Anything else (429, 5xx, CORS) — we don't know.
+    // 429 is common in burst — retryable.
+    if (res.status === 429) return 'rate_limited';
+    // 5xx is also worth a retry, but treat the same conservatively.
+    if (res.status >= 500 && res.status < 600) return 'rate_limited';
     return 'unknown';
   } catch {
-    // Network failure or timeout — we don't know.
-    return 'unknown';
+    // Network failure or timeout — also retryable.
+    return 'rate_limited';
   } finally {
     clearTimeout(timer);
+  }
+}
+
+async function probeOne(
+  chainId: number,
+  host: string,
+  address: string,
+): Promise<'deployed' | 'not_deployed' | 'unknown'> {
+  void chainId;
+  const url = `https://${host}/api/v1/safes/${address}/`;
+  // First attempt + per-chain retries with backoff. The retry budget is
+  // small on purpose: in production the hook fires once per session per
+  // address, and any retry tax is absorbed by the wallet sign-in latency
+  // that happens after.
+  for (let attempt = 0; ; attempt++) {
+    const outcome = await fetchOne(url);
+    if (outcome !== 'rate_limited') {
+      return outcome;
+    }
+    const delay = PROBE_RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) {
+      // Exhausted retries — treat as unknown so the caller can fall back
+      // to the wallet's reported chainId.
+      return 'unknown';
+    }
+    await new Promise((r) => setTimeout(r, delay));
   }
 }
 
@@ -99,6 +126,12 @@ async function probeAllChains(address: string): Promise<SafeDeployments> {
  * any allowlisted chain (treat as EOA). Empty `deployedOn` with a non-empty
  * `unknown` means we couldn't fully probe — consumers should fall back to
  * the wallet's reported chainId rather than assume EOA.
+ *
+ * NOTE: Safe Transaction Service rejects lowercase addresses with HTTP 422
+ * ("Checksum address validation failed"). The address must be passed in
+ * its EIP-55-checksummed form. wagmi's `useAccount().address` is already
+ * checksummed; we cache by the lowercased form for stable React Query
+ * keys but pass the original to the endpoint.
  */
 export function useSafeDeployments(
   address: string | undefined,
@@ -106,11 +139,11 @@ export function useSafeDeployments(
   data: SafeDeployments | undefined;
   isLoading: boolean;
 } {
-  const normalized = address?.toLowerCase();
+  const cacheKey = address?.toLowerCase();
   const query = useQuery({
-    queryKey: ['safe-deployments', normalized],
-    queryFn: () => probeAllChains(normalized as string),
-    enabled: typeof normalized === 'string' && normalized.length > 0,
+    queryKey: ['safe-deployments', cacheKey],
+    queryFn: () => probeAllChains(address as string),
+    enabled: typeof address === 'string' && address.length > 0,
     // Safe deployments are stable for the lifetime of an address. A user
     // could deploy a Safe on a new chain mid-session in theory; fine to
     // miss that until reload.

--- a/src/hooks/useSafeDeployments.ts
+++ b/src/hooks/useSafeDeployments.ts
@@ -1,0 +1,157 @@
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Detect which chains an address is deployed on as a Safe smart-account.
+ *
+ * Safe addresses are deterministic across chains via the Safe Singleton
+ * Factory + CREATE2, so the same address may exist on multiple chains —
+ * or none at all (in which case the address is most likely an EOA).
+ *
+ * From the wallet side (Rabby, MetaMask, WalletConnect, ConnectKit) there
+ * is no EIP-1193 method that says "this account is a Safe" — even Rabby's
+ * Safe-import feature still presents the address through the standard
+ * personal_sign / eth_signTypedData interface. We probe instead: the Safe
+ * Transaction Service exposes a per-chain endpoint that returns 200 when
+ * the address is a deployed Safe on that chain, and 404 otherwise.
+ *
+ * The probe is rate-limited per IP, so network failures or 429s are
+ * surfaced separately from confirmed-not-deployed (404). Consumers can
+ * decide whether an unknown answer should fall back to "treat as EOA"
+ * (current SIWE wallet chain) or wait for retry.
+ */
+
+export interface SafeDeployments {
+  /** chainIds where this address is a deployed Safe (HTTP 200). */
+  readonly deployedOn: readonly number[];
+  /** chainIds we couldn't reach (network error, timeout, 429). */
+  readonly unknown: readonly number[];
+}
+
+/**
+ * Per-chain Safe Transaction Service hosts. Mirrors the Snapshot qidao.eth
+ * matrix — keep in sync with src/config/chains.ts.
+ *
+ * If a chain in our allowlist is missing here, the deployment lookup will
+ * silently treat that chain as "unknown" and the SIWE flow falls back to
+ * the wallet's reported chainId.
+ */
+const SAFE_TX_SERVICE_HOSTS: Readonly<Record<number, string>> = {
+  1: 'safe-transaction-mainnet.safe.global',
+  10: 'safe-transaction-optimism.safe.global',
+  100: 'safe-transaction-gnosis-chain.safe.global',
+  137: 'safe-transaction-polygon.safe.global',
+  8453: 'safe-transaction-base.safe.global',
+  42161: 'safe-transaction-arbitrum.safe.global',
+};
+
+const PROBE_TIMEOUT_MS = 6000;
+
+async function probeOne(
+  chainId: number,
+  host: string,
+  address: string,
+): Promise<'deployed' | 'not_deployed' | 'unknown'> {
+  const url = `https://${host}/api/v1/safes/${address}/`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (res.status === 200) return 'deployed';
+    if (res.status === 404) return 'not_deployed';
+    // Anything else (429, 5xx, CORS) — we don't know.
+    return 'unknown';
+  } catch {
+    // Network failure or timeout — we don't know.
+    return 'unknown';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function probeAllChains(address: string): Promise<SafeDeployments> {
+  const entries = Object.entries(SAFE_TX_SERVICE_HOSTS) as readonly [
+    string,
+    string,
+  ][];
+  const results = await Promise.all(
+    entries.map(async ([chainIdStr, host]) => {
+      const chainId = Number(chainIdStr);
+      const outcome = await probeOne(chainId, host, address);
+      return { chainId, outcome };
+    }),
+  );
+  const deployedOn: number[] = [];
+  const unknown: number[] = [];
+  for (const r of results) {
+    if (r.outcome === 'deployed') deployedOn.push(r.chainId);
+    else if (r.outcome === 'unknown') unknown.push(r.chainId);
+  }
+  return { deployedOn, unknown };
+}
+
+/**
+ * Cached lookup for an address's Safe deployments. Empty `deployedOn` and
+ * empty `unknown` together means we confirmed the address is not a Safe on
+ * any allowlisted chain (treat as EOA). Empty `deployedOn` with a non-empty
+ * `unknown` means we couldn't fully probe — consumers should fall back to
+ * the wallet's reported chainId rather than assume EOA.
+ */
+export function useSafeDeployments(
+  address: string | undefined,
+): {
+  data: SafeDeployments | undefined;
+  isLoading: boolean;
+} {
+  const normalized = address?.toLowerCase();
+  const query = useQuery({
+    queryKey: ['safe-deployments', normalized],
+    queryFn: () => probeAllChains(normalized as string),
+    enabled: typeof normalized === 'string' && normalized.length > 0,
+    // Safe deployments are stable for the lifetime of an address. A user
+    // could deploy a Safe on a new chain mid-session in theory; fine to
+    // miss that until reload.
+    staleTime: Infinity,
+    gcTime: 60 * 60 * 1000, // 1 hour
+    retry: (failureCount, error) => {
+      // The probe never throws (it returns "unknown" on error). If we
+      // got here, retry is unlikely to help.
+      void error;
+      return failureCount < 1;
+    },
+  });
+  return { data: query.data, isLoading: query.isLoading };
+}
+
+/**
+ * Pick the SIWE message chainId given the wallet's reported chain and the
+ * Safe-deployment lookup. Priority:
+ *
+ *   1. Safe deployed on exactly one chain → that chainId (load-bearing
+ *      for EIP-1271: the verifier's RPC must be on the chain where the
+ *      smart-account contract code lives).
+ *   2. Safe deployed on multiple chains AND the wallet's current chain is
+ *      one of them → prefer the wallet's chainId (matches the wallet's
+ *      view of where it's signing).
+ *   3. Safe deployed on multiple chains, wallet's chain not among them →
+ *      first deployment chain (we have to pick one).
+ *   4. Probe didn't conclude (some chains unknown, none confirmed) →
+ *      wallet's chainId — fall back gracefully so a flaky Safe TX
+ *      Service doesn't block sign-in.
+ *   5. Probe concluded but found no deployments → wallet's chainId
+ *      (treat as EOA — chainId is informational for ECDSA recovery).
+ */
+export function pickSiweChainId(
+  walletChainId: number,
+  safeDeployments: SafeDeployments | undefined,
+): number {
+  if (!safeDeployments) return walletChainId;
+  const { deployedOn } = safeDeployments;
+  if (deployedOn.length === 0) return walletChainId;
+  if (deployedOn.length === 1) return deployedOn[0]!;
+  if (deployedOn.includes(walletChainId)) return walletChainId;
+  return deployedOn[0]!;
+}

--- a/src/hooks/useSafeDeployments.ts
+++ b/src/hooks/useSafeDeployments.ts
@@ -1,4 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
+import { getMaiAPIClient } from '../services/maiApiClient';
+import { config } from '../config/env';
 
 /**
  * Detect which chains an address is deployed on as a Safe smart-account.
@@ -10,128 +12,42 @@ import { useQuery } from '@tanstack/react-query';
  * From the wallet side (Rabby, MetaMask, WalletConnect, ConnectKit) there
  * is no EIP-1193 method that says "this account is a Safe" — even Rabby's
  * Safe-import feature still presents the address through the standard
- * personal_sign / eth_signTypedData interface. We probe instead: the Safe
- * Transaction Service exposes a per-chain endpoint that returns 200 when
- * the address is a deployed Safe on that chain, and 404 otherwise.
+ * personal_sign / eth_signTypedData interface. We probe instead.
  *
- * The probe is rate-limited per IP, so network failures or 429s are
- * surfaced separately from confirmed-not-deployed (404). Consumers can
- * decide whether an unknown answer should fall back to "treat as EOA"
- * (current SIWE wallet chain) or wait for retry.
+ * The probe is performed server-side by the mai-api `/v2/safe-deployments`
+ * endpoint, which does on-chain `eth_getCode` + Safe ABI multicall against
+ * mainnet, polygon, base, and linea — the four chains where qidao-relevant
+ * Safes live — with results cached in Redis for 90 days. The frontend used
+ * to fan out to Safe Transaction Service directly, but the unauthenticated
+ * tier there is rate-limited (5,000 req/month / 2 RPS), so the central
+ * endpoint owns the cache and the RPC budget instead.
  */
 
 export interface SafeDeployments {
-  /** chainIds where this address is a deployed Safe (HTTP 200). */
+  /** chainIds where this address is a deployed Safe. */
   readonly deployedOn: readonly number[];
-  /** chainIds we couldn't reach (network error, timeout, 429). */
+  /** chainIds where the lookup couldn't conclude (RPC issue, etc.). */
   readonly unknown: readonly number[];
 }
 
-/**
- * Per-chain Safe Transaction Service hosts. Mirrors the Snapshot qidao.eth
- * matrix — keep in sync with src/config/chains.ts.
- *
- * If a chain in our allowlist is missing here, the deployment lookup will
- * silently treat that chain as "unknown" and the SIWE flow falls back to
- * the wallet's reported chainId.
- */
-const SAFE_TX_SERVICE_HOSTS: Readonly<Record<number, string>> = {
-  1: 'safe-transaction-mainnet.safe.global',
-  10: 'safe-transaction-optimism.safe.global',
-  100: 'safe-transaction-gnosis-chain.safe.global',
-  137: 'safe-transaction-polygon.safe.global',
-  8453: 'safe-transaction-base.safe.global',
-  42161: 'safe-transaction-arbitrum.safe.global',
-};
-
-const PROBE_TIMEOUT_MS = 6000;
-const PROBE_RETRY_DELAYS_MS = [1000, 3000] as const;
-
-async function fetchOne(
-  url: string,
-): Promise<'deployed' | 'not_deployed' | 'rate_limited' | 'unknown'> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+async function fetchSafeDeployments(address: string): Promise<SafeDeployments> {
+  const client = getMaiAPIClient(config.maiApiUrl);
   try {
-    const res = await fetch(url, {
-      method: 'GET',
-      headers: { accept: 'application/json' },
-      signal: controller.signal,
-    });
-    if (res.status === 200) return 'deployed';
-    if (res.status === 404) return 'not_deployed';
-    // 429 is common in burst — retryable.
-    if (res.status === 429) return 'rate_limited';
-    // 5xx is also worth a retry, but treat the same conservatively.
-    if (res.status >= 500 && res.status < 600) return 'rate_limited';
-    return 'unknown';
+    const res = await client.getSafeDeployments(address);
+    return { deployedOn: res.deployedOn, unknown: res.unknown };
   } catch {
-    // Network failure or timeout — also retryable.
-    return 'rate_limited';
-  } finally {
-    clearTimeout(timer);
+    // Endpoint unavailable / network error — treat as fully unknown.
+    // pickSiweChainId then falls back to the wallet's reported chainId.
+    return { deployedOn: [], unknown: [1, 137, 8453, 59144] };
   }
-}
-
-async function probeOne(
-  chainId: number,
-  host: string,
-  address: string,
-): Promise<'deployed' | 'not_deployed' | 'unknown'> {
-  void chainId;
-  const url = `https://${host}/api/v1/safes/${address}/`;
-  // First attempt + per-chain retries with backoff. The retry budget is
-  // small on purpose: in production the hook fires once per session per
-  // address, and any retry tax is absorbed by the wallet sign-in latency
-  // that happens after.
-  for (let attempt = 0; ; attempt++) {
-    const outcome = await fetchOne(url);
-    if (outcome !== 'rate_limited') {
-      return outcome;
-    }
-    const delay = PROBE_RETRY_DELAYS_MS[attempt];
-    if (delay === undefined) {
-      // Exhausted retries — treat as unknown so the caller can fall back
-      // to the wallet's reported chainId.
-      return 'unknown';
-    }
-    await new Promise((r) => setTimeout(r, delay));
-  }
-}
-
-async function probeAllChains(address: string): Promise<SafeDeployments> {
-  const entries = Object.entries(SAFE_TX_SERVICE_HOSTS) as readonly [
-    string,
-    string,
-  ][];
-  const results = await Promise.all(
-    entries.map(async ([chainIdStr, host]) => {
-      const chainId = Number(chainIdStr);
-      const outcome = await probeOne(chainId, host, address);
-      return { chainId, outcome };
-    }),
-  );
-  const deployedOn: number[] = [];
-  const unknown: number[] = [];
-  for (const r of results) {
-    if (r.outcome === 'deployed') deployedOn.push(r.chainId);
-    else if (r.outcome === 'unknown') unknown.push(r.chainId);
-  }
-  return { deployedOn, unknown };
 }
 
 /**
  * Cached lookup for an address's Safe deployments. Empty `deployedOn` and
  * empty `unknown` together means we confirmed the address is not a Safe on
- * any allowlisted chain (treat as EOA). Empty `deployedOn` with a non-empty
- * `unknown` means we couldn't fully probe — consumers should fall back to
- * the wallet's reported chainId rather than assume EOA.
- *
- * NOTE: Safe Transaction Service rejects lowercase addresses with HTTP 422
- * ("Checksum address validation failed"). The address must be passed in
- * its EIP-55-checksummed form. wagmi's `useAccount().address` is already
- * checksummed; we cache by the lowercased form for stable React Query
- * keys but pass the original to the endpoint.
+ * any of the four target chains (treat as EOA). Empty `deployedOn` with a
+ * non-empty `unknown` means we couldn't fully probe — consumers should
+ * fall back to the wallet's reported chainId rather than assume EOA.
  */
 export function useSafeDeployments(
   address: string | undefined,
@@ -142,17 +58,17 @@ export function useSafeDeployments(
   const cacheKey = address?.toLowerCase();
   const query = useQuery({
     queryKey: ['safe-deployments', cacheKey],
-    queryFn: () => probeAllChains(address as string),
+    queryFn: () => fetchSafeDeployments(address as string),
     enabled: typeof address === 'string' && address.length > 0,
-    // Safe deployments are stable for the lifetime of an address. A user
-    // could deploy a Safe on a new chain mid-session in theory; fine to
-    // miss that until reload.
+    // Safe deployments are stable for the lifetime of an address. The
+    // server-side cache TTL is 90 days; React Query keeps the result
+    // for the whole session.
     staleTime: Infinity,
     gcTime: 60 * 60 * 1000, // 1 hour
     retry: (failureCount, error) => {
-      // The probe never throws (it returns "unknown" on error). If we
-      // got here, retry is unlikely to help.
       void error;
+      // fetchSafeDeployments never throws (it catches and returns
+      // a fully-unknown result), so retries here would be pointless.
       return failureCount < 1;
     },
   });
@@ -172,8 +88,8 @@ export function useSafeDeployments(
  *   3. Safe deployed on multiple chains, wallet's chain not among them →
  *      first deployment chain (we have to pick one).
  *   4. Probe didn't conclude (some chains unknown, none confirmed) →
- *      wallet's chainId — fall back gracefully so a flaky Safe TX
- *      Service doesn't block sign-in.
+ *      wallet's chainId — fall back gracefully so a flaky Safe API
+ *      doesn't block sign-in.
  *   5. Probe concluded but found no deployments → wallet's chainId
  *      (treat as EOA — chainId is informational for ECDSA recovery).
  */

--- a/src/hooks/useSiweSession.ts
+++ b/src/hooks/useSiweSession.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
-import { useAccount, useSignMessage } from 'wagmi';
+import { useAccount, useChainId, useSignMessage } from 'wagmi';
 import { SiweMessage } from 'siwe';
 import { getMaiAPIClient } from '../services/maiApiClient';
 import { config } from '../config/env';
@@ -39,13 +39,6 @@ export interface UseSiweSessionResult {
 
 const STATEMENT = 'Sign in to leave a comment on this QIP.';
 const NONCE_TTL_SECONDS = 10 * 60;
-/**
- * The Snapshot space we vote on lives on Ethereum mainnet. Keeping the
- * SIWE message's chainId at 1 makes the wallet pop-up display the
- * familiar mainnet network name; the actual on-chain chain the wallet
- * is connected to is not relevant to a SIWE attestation.
- */
-const SIWE_CHAIN_ID = 1;
 
 /* ─────────────────────────────────────────────────────────
    Shared session state (module-scoped singleton)
@@ -86,6 +79,12 @@ function subscribeSessionState(listener: () => void): () => void {
 
 export function useSiweSession(): UseSiweSessionResult {
   const { address: walletAddress, isConnected } = useAccount();
+  // EIP-4361 requires a chainId in the SIWE message; for EOAs it is
+  // informational, but for smart-account signers (Safe and other EIP-1271
+  // wallets) it tells the verifier which chain's RPC to query for
+  // `isValidSignature`. Reading the wallet's actual chain — not a
+  // hardcoded constant — is what lets a Safe on Polygon sign here.
+  const walletChainId = useChainId();
   const { signMessageAsync } = useSignMessage();
 
   const state = useSyncExternalStore(
@@ -136,7 +135,7 @@ export function useSiweSession(): UseSiweSessionResult {
         statement: STATEMENT,
         uri: window.location.origin,
         version: '1',
-        chainId: SIWE_CHAIN_ID,
+        chainId: walletChainId,
         nonce: nonceResp.nonce,
         issuedAt: issuedAt.toISOString(),
         expirationTime: expirationTime.toISOString(),
@@ -185,7 +184,7 @@ export function useSiweSession(): UseSiweSessionResult {
       setSessionState({ ...sessionState, status: 'idle' });
       return { ok: false, reason: 'unknown' };
     }
-  }, [isConnected, walletAddress, signMessageAsync]);
+  }, [isConnected, walletAddress, walletChainId, signMessageAsync]);
 
   const signOut = useCallback(() => {
     setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });

--- a/src/hooks/useSiweSession.ts
+++ b/src/hooks/useSiweSession.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAccount, useSignMessage } from 'wagmi';
+import { SiweMessage } from 'siwe';
+import { getMaiAPIClient } from '../services/maiApiClient';
+import { config } from '../config/env';
+
+export type SiweSessionStatus = 'idle' | 'signing' | 'authenticated';
+
+/**
+ * Reason a sign-in attempt did not produce a session. The caller renders
+ * these as toasts; "user_rejected" is silent because the user just clicked
+ * cancel in the wallet.
+ */
+export type SiweSignInError =
+  | 'no_wallet'
+  | 'user_rejected'
+  | 'verify_failed'
+  | 'unknown';
+
+export interface UseSiweSessionResult {
+  status: SiweSessionStatus;
+  /** Lowercased authenticated address, present iff status === 'authenticated'. */
+  address?: string;
+  /** In-memory bearer token. Never persisted to localStorage / sessionStorage. */
+  sessionToken?: string;
+  isPending: boolean;
+
+  /** Run the nonce → sign → verify dance. Throws nothing; errors surface as `error` state. */
+  signIn: () => Promise<{ ok: true } | { ok: false; reason: SiweSignInError }>;
+  /** Clear local session state. Best-effort; the cookie is left in place. */
+  signOut: () => void;
+  /**
+   * Force-clear the session because an authenticated request returned 401.
+   * Called by the parent component when a comment POST surfaces an expired
+   * session, so the user is prompted to sign in again.
+   */
+  clearOn401: () => void;
+}
+
+const STATEMENT = 'Sign in to leave a comment on this QIP.';
+const NONCE_TTL_SECONDS = 10 * 60;
+/**
+ * The Snapshot space we vote on lives on Ethereum mainnet. Keeping the
+ * SIWE message's chainId at 1 makes the wallet pop-up display the
+ * familiar mainnet network name; the actual on-chain chain the wallet
+ * is connected to is not relevant to a SIWE attestation.
+ */
+const SIWE_CHAIN_ID = 1;
+
+export function useSiweSession(): UseSiweSessionResult {
+  const { address: walletAddress, isConnected } = useAccount();
+  const { signMessageAsync } = useSignMessage();
+
+  const [status, setStatus] = useState<SiweSessionStatus>('idle');
+  const [sessionToken, setSessionToken] = useState<string | undefined>(undefined);
+  const [authedAddress, setAuthedAddress] = useState<string | undefined>(undefined);
+
+  // If the user disconnects their wallet (or switches accounts), drop the
+  // local session — it's no longer attributable to whoever's currently
+  // controlling the page.
+  useEffect(() => {
+    if (!isConnected) {
+      setStatus('idle');
+      setSessionToken(undefined);
+      setAuthedAddress(undefined);
+      return;
+    }
+    if (
+      authedAddress &&
+      walletAddress &&
+      authedAddress.toLowerCase() !== walletAddress.toLowerCase()
+    ) {
+      setStatus('idle');
+      setSessionToken(undefined);
+      setAuthedAddress(undefined);
+    }
+  }, [isConnected, walletAddress, authedAddress]);
+
+  const signIn = useCallback(async (): Promise<
+    { ok: true } | { ok: false; reason: SiweSignInError }
+  > => {
+    if (!isConnected || !walletAddress) {
+      return { ok: false, reason: 'no_wallet' };
+    }
+
+    setStatus('signing');
+    try {
+      const client = getMaiAPIClient(config.maiApiUrl);
+
+      // 1. Get a nonce bound to the connecting address.
+      const nonceResp = await client.requestQipCommentNonce(walletAddress);
+
+      // 2. Build the SIWE message.
+      const issuedAt = new Date();
+      const expirationTime = new Date(issuedAt.getTime() + NONCE_TTL_SECONDS * 1000);
+      const message = new SiweMessage({
+        domain: window.location.host,
+        address: walletAddress,
+        statement: STATEMENT,
+        uri: window.location.origin,
+        version: '1',
+        chainId: SIWE_CHAIN_ID,
+        nonce: nonceResp.nonce,
+        issuedAt: issuedAt.toISOString(),
+        expirationTime: expirationTime.toISOString(),
+      });
+      const messageBody = message.prepareMessage();
+
+      // 3. Sign with the connected wallet. User rejection lands in the catch.
+      let signature: string;
+      try {
+        signature = await signMessageAsync({ message: messageBody });
+      } catch (err) {
+        setStatus('idle');
+        // Wagmi surfaces a UserRejectedRequestError when the user cancels.
+        if (
+          err instanceof Error &&
+          /reject|denied|cancel/i.test(err.message)
+        ) {
+          return { ok: false, reason: 'user_rejected' };
+        }
+        return { ok: false, reason: 'unknown' };
+      }
+
+      // 4. Verify with the API and capture the bearer token.
+      const verifyResp = await client.verifyQipCommentSignature({
+        message: messageBody,
+        signature,
+      });
+
+      const lowercased = verifyResp.address.toLowerCase();
+      setAuthedAddress(lowercased);
+      setSessionToken(verifyResp.token);
+      setStatus('authenticated');
+      return { ok: true };
+    } catch {
+      setStatus('idle');
+      return { ok: false, reason: 'verify_failed' };
+    }
+  }, [isConnected, walletAddress, signMessageAsync]);
+
+  const signOut = useCallback(() => {
+    setStatus('idle');
+    setSessionToken(undefined);
+    setAuthedAddress(undefined);
+  }, []);
+
+  const clearOn401 = useCallback(() => {
+    // Same effect as signOut, but the name flags the intent at the call
+    // site so it's clear we're reacting to a server-side session expiry,
+    // not a user action.
+    setStatus('idle');
+    setSessionToken(undefined);
+    setAuthedAddress(undefined);
+  }, []);
+
+  return {
+    status,
+    address: authedAddress,
+    sessionToken,
+    isPending: status === 'signing',
+    signIn,
+    signOut,
+    clearOn401,
+  };
+}

--- a/src/hooks/useSiweSession.ts
+++ b/src/hooks/useSiweSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import { useAccount, useSignMessage } from 'wagmi';
 import { SiweMessage } from 'siwe';
 import { getMaiAPIClient } from '../services/maiApiClient';
@@ -47,34 +47,71 @@ const NONCE_TTL_SECONDS = 10 * 60;
  */
 const SIWE_CHAIN_ID = 1;
 
+/* ─────────────────────────────────────────────────────────
+   Shared session state (module-scoped singleton)
+   ─────────────────────────────────────────────────────────
+   Every consumer of useSiweSession needs to see the same token and status,
+   not its own local copy. Without a shared store, signing in inside one
+   component's tree leaves siblings unaware that a session exists, so the
+   composer never replaces the login button.
+ */
+
+interface SessionState {
+  status: SiweSessionStatus;
+  sessionToken: string | undefined;
+  address: string | undefined;
+}
+
+let sessionState: SessionState = {
+  status: 'idle',
+  sessionToken: undefined,
+  address: undefined,
+};
+
+const subscribers = new Set<() => void>();
+
+function getSessionSnapshot(): SessionState {
+  return sessionState;
+}
+
+function setSessionState(next: SessionState): void {
+  sessionState = next;
+  for (const listener of subscribers) listener();
+}
+
+function subscribeSessionState(listener: () => void): () => void {
+  subscribers.add(listener);
+  return () => subscribers.delete(listener);
+}
+
 export function useSiweSession(): UseSiweSessionResult {
   const { address: walletAddress, isConnected } = useAccount();
   const { signMessageAsync } = useSignMessage();
 
-  const [status, setStatus] = useState<SiweSessionStatus>('idle');
-  const [sessionToken, setSessionToken] = useState<string | undefined>(undefined);
-  const [authedAddress, setAuthedAddress] = useState<string | undefined>(undefined);
+  const state = useSyncExternalStore(
+    subscribeSessionState,
+    getSessionSnapshot,
+    getSessionSnapshot,
+  );
 
   // If the user disconnects their wallet (or switches accounts), drop the
   // local session — it's no longer attributable to whoever's currently
   // controlling the page.
   useEffect(() => {
     if (!isConnected) {
-      setStatus('idle');
-      setSessionToken(undefined);
-      setAuthedAddress(undefined);
+      if (sessionState.sessionToken !== undefined || sessionState.status !== 'idle') {
+        setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
+      }
       return;
     }
     if (
-      authedAddress &&
+      sessionState.address &&
       walletAddress &&
-      authedAddress.toLowerCase() !== walletAddress.toLowerCase()
+      sessionState.address.toLowerCase() !== walletAddress.toLowerCase()
     ) {
-      setStatus('idle');
-      setSessionToken(undefined);
-      setAuthedAddress(undefined);
+      setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
     }
-  }, [isConnected, walletAddress, authedAddress]);
+  }, [isConnected, walletAddress]);
 
   const signIn = useCallback(async (): Promise<
     { ok: true } | { ok: false; reason: SiweSignInError }
@@ -83,7 +120,7 @@ export function useSiweSession(): UseSiweSessionResult {
       return { ok: false, reason: 'no_wallet' };
     }
 
-    setStatus('signing');
+    setSessionState({ ...sessionState, status: 'signing' });
     try {
       const client = getMaiAPIClient(config.maiApiUrl);
 
@@ -111,8 +148,7 @@ export function useSiweSession(): UseSiweSessionResult {
       try {
         signature = await signMessageAsync({ message: messageBody });
       } catch (err) {
-        setStatus('idle');
-        // Wagmi surfaces a UserRejectedRequestError when the user cancels.
+        setSessionState({ ...sessionState, status: 'idle' });
         if (
           err instanceof Error &&
           /reject|denied|cancel/i.test(err.message)
@@ -123,42 +159,50 @@ export function useSiweSession(): UseSiweSessionResult {
       }
 
       // 4. Verify with the API and capture the bearer token.
-      const verifyResp = await client.verifyQipCommentSignature({
-        message: messageBody,
-        signature,
-      });
+      let verifyResp;
+      try {
+        verifyResp = await client.verifyQipCommentSignature({
+          message: messageBody,
+          signature,
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[useSiweSession] verify failed:', err);
+        setSessionState({ ...sessionState, status: 'idle' });
+        return { ok: false, reason: 'verify_failed' };
+      }
 
       const lowercased = verifyResp.address.toLowerCase();
-      setAuthedAddress(lowercased);
-      setSessionToken(verifyResp.token);
-      setStatus('authenticated');
+      setSessionState({
+        status: 'authenticated',
+        sessionToken: verifyResp.token,
+        address: lowercased,
+      });
       return { ok: true };
-    } catch {
-      setStatus('idle');
-      return { ok: false, reason: 'verify_failed' };
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[useSiweSession] sign-in failed before verify:', err);
+      setSessionState({ ...sessionState, status: 'idle' });
+      return { ok: false, reason: 'unknown' };
     }
   }, [isConnected, walletAddress, signMessageAsync]);
 
   const signOut = useCallback(() => {
-    setStatus('idle');
-    setSessionToken(undefined);
-    setAuthedAddress(undefined);
+    setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
   }, []);
 
   const clearOn401 = useCallback(() => {
     // Same effect as signOut, but the name flags the intent at the call
     // site so it's clear we're reacting to a server-side session expiry,
     // not a user action.
-    setStatus('idle');
-    setSessionToken(undefined);
-    setAuthedAddress(undefined);
+    setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
   }, []);
 
   return {
-    status,
-    address: authedAddress,
-    sessionToken,
-    isPending: status === 'signing',
+    status: state.status,
+    address: state.address,
+    sessionToken: state.sessionToken,
+    isPending: state.status === 'signing',
     signIn,
     signOut,
     clearOn401,

--- a/src/hooks/useSiweSession.ts
+++ b/src/hooks/useSiweSession.ts
@@ -3,6 +3,7 @@ import { useAccount, useChainId, useSignMessage } from 'wagmi';
 import { SiweMessage } from 'siwe';
 import { getMaiAPIClient } from '../services/maiApiClient';
 import { config } from '../config/env';
+import { pickSiweChainId, useSafeDeployments } from './useSafeDeployments';
 
 export type SiweSessionStatus = 'idle' | 'signing' | 'authenticated';
 
@@ -79,13 +80,25 @@ function subscribeSessionState(listener: () => void): () => void {
 
 export function useSiweSession(): UseSiweSessionResult {
   const { address: walletAddress, isConnected } = useAccount();
-  // EIP-4361 requires a chainId in the SIWE message; for EOAs it is
-  // informational, but for smart-account signers (Safe and other EIP-1271
+  // EIP-4361 requires a chainId in the SIWE message. For EOAs it is
+  // informational; for smart-account signers (Safe and other EIP-1271
   // wallets) it tells the verifier which chain's RPC to query for
-  // `isValidSignature`. Reading the wallet's actual chain — not a
-  // hardcoded constant — is what lets a Safe on Polygon sign here.
+  // `isValidSignature`. The wallet's reported chain is the right answer
+  // when the wallet is actually on its Safe's home chain, but Safes are
+  // often connected through wrappers (Rabby's Safe import, ConnectKit's
+  // initialChainId on Base) where the wallet may report a chain that
+  // doesn't match where the Safe is deployed. So we additionally probe
+  // the Safe Transaction Service to find the deployment chain(s) and let
+  // pickSiweChainId resolve the right answer.
   const walletChainId = useChainId();
   const { signMessageAsync } = useSignMessage();
+
+  // Kick off the deployment probe as soon as a wallet is connected — by
+  // the time the user clicks the sign-in button, the result is usually
+  // already cached. If the probe is still inflight or returned only
+  // unknowns, pickSiweChainId falls back to walletChainId so a flaky
+  // Safe TX Service never blocks sign-in.
+  const { data: safeDeployments } = useSafeDeployments(walletAddress);
 
   const state = useSyncExternalStore(
     subscribeSessionState,
@@ -129,13 +142,14 @@ export function useSiweSession(): UseSiweSessionResult {
       // 2. Build the SIWE message.
       const issuedAt = new Date();
       const expirationTime = new Date(issuedAt.getTime() + NONCE_TTL_SECONDS * 1000);
+      const siweChainId = pickSiweChainId(walletChainId, safeDeployments);
       const message = new SiweMessage({
         domain: window.location.host,
         address: walletAddress,
         statement: STATEMENT,
         uri: window.location.origin,
         version: '1',
-        chainId: walletChainId,
+        chainId: siweChainId,
         nonce: nonceResp.nonce,
         issuedAt: issuedAt.toISOString(),
         expirationTime: expirationTime.toISOString(),
@@ -184,7 +198,7 @@ export function useSiweSession(): UseSiweSessionResult {
       setSessionState({ ...sessionState, status: 'idle' });
       return { ok: false, reason: 'unknown' };
     }
-  }, [isConnected, walletAddress, walletChainId, signMessageAsync]);
+  }, [isConnected, walletAddress, walletChainId, safeDeployments, signMessageAsync]);
 
   const signOut = useCallback(() => {
     setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });

--- a/src/hooks/useSiweSession.ts
+++ b/src/hooks/useSiweSession.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
-import { useAccount, useChainId, useSignMessage } from 'wagmi';
+import { useAccount, useChainId, useSignMessage, useSwitchChain } from 'wagmi';
 import { SiweMessage } from 'siwe';
 import { getMaiAPIClient } from '../services/maiApiClient';
 import { config } from '../config/env';
@@ -15,6 +15,7 @@ export type SiweSessionStatus = 'idle' | 'signing' | 'authenticated';
 export type SiweSignInError =
   | 'no_wallet'
   | 'user_rejected'
+  | 'wrong_chain'
   | 'verify_failed'
   | 'unknown';
 
@@ -92,6 +93,7 @@ export function useSiweSession(): UseSiweSessionResult {
   // pickSiweChainId resolve the right answer.
   const walletChainId = useChainId();
   const { signMessageAsync } = useSignMessage();
+  const { switchChainAsync } = useSwitchChain();
 
   // Kick off the deployment probe as soon as a wallet is connected — by
   // the time the user clicks the sign-in button, the result is usually
@@ -143,6 +145,25 @@ export function useSiweSession(): UseSiweSessionResult {
       const issuedAt = new Date();
       const expirationTime = new Date(issuedAt.getTime() + NONCE_TTL_SECONDS * 1000);
       const siweChainId = pickSiweChainId(walletChainId, safeDeployments);
+
+      // 2a. If the wallet is on a different chain than where the Safe lives,
+      // switch first. EIP-1271 verification reads `isValidSignature` from
+      // the chain in the SIWE message, but the wallet (e.g. Rabby's
+      // Safe-import flow) only proposes signatures via the Safe Transaction
+      // Service for its currently-selected chain. Without this switch,
+      // signing either silently fails or the wallet signs against the
+      // wrong chain and verify rejects.
+      if (walletChainId !== siweChainId) {
+        try {
+          await switchChainAsync({ chainId: siweChainId });
+        } catch (err) {
+          setSessionState({ ...sessionState, status: 'idle' });
+          // User rejected the network switch, or the wallet doesn't
+          // support programmatic switches.
+          return { ok: false, reason: 'wrong_chain' };
+        }
+      }
+
       const message = new SiweMessage({
         domain: window.location.host,
         address: walletAddress,
@@ -198,7 +219,7 @@ export function useSiweSession(): UseSiweSessionResult {
       setSessionState({ ...sessionState, status: 'idle' });
       return { ok: false, reason: 'unknown' };
     }
-  }, [isConnected, walletAddress, walletChainId, safeDeployments, signMessageAsync]);
+  }, [isConnected, walletAddress, walletChainId, safeDeployments, signMessageAsync, switchChainAsync]);
 
   const signOut = useCallback(() => {
     setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });

--- a/src/pages/QCIDetail.tsx
+++ b/src/pages/QCIDetail.tsx
@@ -22,6 +22,7 @@ import SnapshotModerator from "../components/SnapshotModerator";
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { config } from '../config/env'
+import { Comments } from '../components/Comments'
 
 const QCIDetail: React.FC = () => {
   const { qciNumber } = useParams<{ qciNumber: string }>()
@@ -528,6 +529,8 @@ const QCIDetail: React.FC = () => {
             )}
           </div>
         )}
+
+        <Comments qciId={qciData.qciNumber} />
       </div>
     </div>
   );

--- a/src/providers/Web3Provider.tsx
+++ b/src/providers/Web3Provider.tsx
@@ -3,7 +3,7 @@ import { WagmiProvider, createConfig, http } from "wagmi";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ConnectKitProvider } from "connectkit";
-import { mainnet } from "wagmi/chains";
+import { arbitrum, base, baseSepolia, gnosis, mainnet, optimism, polygon } from "wagmi/chains";
 import { injected, walletConnect } from "wagmi/connectors";
 import { config, getChains, getDefaultChainId, localBaseFork } from "../config";
 import { createQueryClient, setupPersistentCache, clearQCICacheOnFreshLoad, CACHE_TIMES } from "../config/queryClient";
@@ -15,12 +15,27 @@ import { ALL_STATUS_NAMES, ALL_STATUS_HASHES } from "../config/statusConfig";
 // Get chains from config
 const chains = getChains();
 
-// Transports configuration
+// Optional per-chain RPC overrides. Empty string falls through to viem's
+// chain-default public RPC, which is fine for the connect-time reads we do
+// on the comments path (low volume); the SIWE-verify hot path runs on
+// mai-api with paid RPCs configured per chain via QIP_COMMENTS_RPC_URL_<id>.
+const rpcEnv = (key: string): string | undefined => {
+  const value = (import.meta as any)?.env?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+// Transports — mirror getChains() so every chain in the allowlist has an
+// http transport. Chains here MUST stay in sync with src/config/chains.ts;
+// missing entries silently break wagmi reads on that chain.
 const transports = {
   [localBaseFork.id]: http(config.baseRpcUrl),
-  [8453]: http(config.baseRpcUrl), // Base
-  [84532]: http(), // Base Sepolia
-  [mainnet.id]: http(),
+  [base.id]: http(rpcEnv("VITE_BASE_RPC_URL") ?? config.baseRpcUrl),
+  [baseSepolia.id]: http(rpcEnv("VITE_BASE_SEPOLIA_RPC_URL")),
+  [mainnet.id]: http(rpcEnv("VITE_MAINNET_RPC_URL")),
+  [optimism.id]: http(rpcEnv("VITE_OPTIMISM_RPC_URL")),
+  [gnosis.id]: http(rpcEnv("VITE_GNOSIS_RPC_URL")),
+  [polygon.id]: http(rpcEnv("VITE_POLYGON_RPC_URL")),
+  [arbitrum.id]: http(rpcEnv("VITE_ARBITRUM_RPC_URL")),
 };
 
 // Wagmi configuration

--- a/src/services/maiApiClient.ts
+++ b/src/services/maiApiClient.ts
@@ -5,6 +5,17 @@
  */
 
 import { QCIStatus } from './qciClient';
+import type {
+  CommentListResponse,
+  ListCommentsOptions,
+  ModerationRequest,
+  ModerationResponse,
+  NonceResponse,
+  PostCommentRequest,
+  PostCommentResponse,
+  VerifyRequest,
+  VerifyResponse,
+} from '../types/comments';
 
 /**
  * QCI data as returned by the Mai API
@@ -183,6 +194,217 @@ export class MaiAPIClient {
     };
 
     return statusMap[status] || `Status ${status}`;
+  }
+
+  /* ─────────────────────────────────────────────────────────
+     QIP comments — auth (SIWE)
+     ───────────────────────────────────────────────────────── */
+
+  /**
+   * Request a single-use SIWE nonce bound to the given address.
+   *
+   * Caller signs the SIWE message containing this nonce, then submits the
+   * message + signature to verifyQipCommentSignature(). The plaintext nonce
+   * is returned once; only the HMAC hash is persisted server-side.
+   */
+  async requestQipCommentNonce(address: string): Promise<NonceResponse> {
+    return this.commentsJsonRequest<NonceResponse>(
+      'POST',
+      '/v2/auth/qip-comments/nonce',
+      { address },
+    );
+  }
+
+  /**
+   * Verify a SIWE signature and exchange it for a session.
+   *
+   * On success returns a bearer token (kept in memory only — never persist
+   * to localStorage) and the API also sets a same-origin HttpOnly session
+   * cookie. Subsequent comment writes can use either authentication path.
+   */
+  async verifyQipCommentSignature(req: VerifyRequest): Promise<VerifyResponse> {
+    return this.commentsJsonRequest<VerifyResponse>(
+      'POST',
+      '/v2/auth/qip-comments/verify',
+      req,
+    );
+  }
+
+  /* ─────────────────────────────────────────────────────────
+     QIP comments — public reads + gated writes
+     ───────────────────────────────────────────────────────── */
+
+  /**
+   * List visible (non-hidden) comments for a QCI, newest-first.
+   *
+   * No auth required for reading. Use the `before` cursor (returned as
+   * `nextBefore` in each page) for infinite-scroll pagination. Hidden
+   * comments are filtered server-side and never appear in the response.
+   */
+  async listQipComments(opts: ListCommentsOptions): Promise<CommentListResponse> {
+    const params = new URLSearchParams();
+    params.append('qciId', String(opts.qciId));
+    if (opts.limit !== undefined) params.append('limit', String(opts.limit));
+    if (opts.before !== undefined) params.append('before', String(opts.before));
+
+    const url = `${this.baseUrl}/v2/comments?${params.toString()}`;
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (opts.sessionToken) {
+      headers.Authorization = `Bearer ${opts.sessionToken}`;
+    }
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+      credentials: opts.sessionToken ? 'omit' : 'include',
+      signal: AbortSignal.timeout(this.defaultTimeout),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Mai API request failed: ${response.status} ${response.statusText}`);
+    }
+    return (await response.json()) as CommentListResponse;
+  }
+
+  /**
+   * Post a comment on a QCI.
+   *
+   * Returns a discriminated union — callers should branch on `result.ok`
+   * and `result.status`. The 403 case carries the API's actual `threshold`
+   * and `currentVp` so the toast can render the values the server saw,
+   * not anything the client computed locally.
+   */
+  async postQipComment(req: PostCommentRequest): Promise<PostCommentResponse> {
+    return this.commentsResultRequest<PostCommentResponse>(
+      'POST',
+      '/v2/comments',
+      { qciId: req.qciId, body: req.body },
+      req.sessionToken,
+      (status, comment) => ({ ok: true, status, comment }) as never,
+    ) as Promise<PostCommentResponse>;
+  }
+
+  /** Editor-only: hide a comment. Idempotent — 409 if already hidden. */
+  async hideQipComment(req: ModerationRequest): Promise<ModerationResponse> {
+    return this.commentsResultRequest<ModerationResponse>(
+      'POST',
+      `/v2/comments/${req.commentId}/hide`,
+      req.reason !== undefined ? { reason: req.reason } : {},
+      req.sessionToken,
+      (_status, payload) => ({
+        ok: true,
+        commentId: (payload as { commentId: number }).commentId,
+        actionId: (payload as { actionId: number }).actionId,
+      }),
+    ) as Promise<ModerationResponse>;
+  }
+
+  /** Editor-only: unhide a previously hidden comment. */
+  async unhideQipComment(req: ModerationRequest): Promise<ModerationResponse> {
+    return this.commentsResultRequest<ModerationResponse>(
+      'POST',
+      `/v2/comments/${req.commentId}/unhide`,
+      req.reason !== undefined ? { reason: req.reason } : {},
+      req.sessionToken,
+      (_status, payload) => ({
+        ok: true,
+        commentId: (payload as { commentId: number }).commentId,
+        actionId: (payload as { actionId: number }).actionId,
+      }),
+    ) as Promise<ModerationResponse>;
+  }
+
+  /* ─────────────────────────────────────────────────────────
+     Shared transport helpers for the comment endpoints
+     ───────────────────────────────────────────────────────── */
+
+  /**
+   * Fire a JSON request and throw on any non-2xx — used for the auth
+   * endpoints where every failure is fatal to the flow.
+   */
+  private async commentsJsonRequest<T>(
+    method: string,
+    path: string,
+    body: unknown,
+  ): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.defaultTimeout),
+    });
+
+    if (!response.ok) {
+      let detail = '';
+      try {
+        const errBody = (await response.json()) as { error?: string; message?: string };
+        detail = errBody.error || errBody.message || '';
+      } catch {
+        // Non-JSON error body; fall through to status text.
+      }
+      throw new Error(
+        `Mai API ${path} failed: ${response.status} ${response.statusText}${
+          detail ? ` (${detail})` : ''
+        }`,
+      );
+    }
+    return (await response.json()) as T;
+  }
+
+  /**
+   * Fire a JSON request and return a discriminated `{ ok, ... }` result for
+   * routes whose error states the caller wants to pattern-match (POST
+   * comment, moderation actions). Auth failures and rate limits are NOT
+   * thrown — they're returned as structured errors.
+   */
+  private async commentsResultRequest<TResult>(
+    method: string,
+    path: string,
+    body: unknown,
+    sessionToken: string | undefined,
+    onSuccess: (status: number, payload: unknown) => unknown,
+  ): Promise<TResult> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    if (sessionToken) {
+      headers.Authorization = `Bearer ${sessionToken}`;
+    }
+
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      // Bearer wins when present — don't also send the cookie. Cookie
+      // travels only when no token is supplied (same-origin path).
+      credentials: sessionToken ? 'omit' : 'include',
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.defaultTimeout),
+    });
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = {};
+    }
+
+    if (response.ok) {
+      return onSuccess(response.status, payload) as TResult;
+    }
+
+    // Coerce the server's structured error into the discriminated shape.
+    const err = payload as Record<string, unknown>;
+    const base = {
+      ok: false as const,
+      status: response.status as 401 | 403 | 404 | 409 | 413 | 429 | 503 | 400 | 500,
+      error: typeof err.error === 'string' ? err.error : 'unknown',
+    };
+    return { ...base, ...err } as TResult;
   }
 
   /**

--- a/src/services/maiApiClient.ts
+++ b/src/services/maiApiClient.ts
@@ -253,10 +253,15 @@ export class MaiAPIClient {
       headers.Authorization = `Bearer ${opts.sessionToken}`;
     }
 
+    // GET is anonymous-by-default — the comment list does not require
+    // auth. Use credentials: 'omit' so cross-origin reads aren't blocked
+    // by the CORS preflight against `Access-Control-Allow-Origin: *`
+    // (browsers reject `*` + `credentials: include`). Same-origin reads
+    // don't need cookies for this route.
     const response = await fetch(url, {
       method: 'GET',
       headers,
-      credentials: opts.sessionToken ? 'omit' : 'include',
+      credentials: 'omit',
       signal: AbortSignal.timeout(this.defaultTimeout),
     });
 

--- a/src/services/maiApiClient.ts
+++ b/src/services/maiApiClient.ts
@@ -304,6 +304,58 @@ export class MaiAPIClient {
     ) as Promise<ModerationResponse>;
   }
 
+  /* ─────────────────────────────────────────────────────────
+     QIP comments — Safe deployment lookup
+     ───────────────────────────────────────────────────────── */
+
+  /**
+   * Look up which chains an address is deployed on as a Safe.
+   *
+   * Server probes mainnet, polygon, base, and linea via on-chain RPC
+   * (eth_getCode + Safe ABI multicall) with results cached in Redis for
+   * 90 days. The frontend uses the `deployedOn` list to pick the right
+   * chainId for the SIWE message — load-bearing for EIP-1271 verification.
+   *
+   * `unknown` lists chains where the lookup couldn't conclude (RPC down,
+   * env var missing); the caller's job is to treat unknown chains the
+   * same as not-yet-probed and fall back to the wallet's reported chain.
+   */
+  async getSafeDeployments(
+    address: string,
+  ): Promise<{
+    address: string;
+    deployedOn: number[];
+    unknown: number[];
+    details: Record<
+      number,
+      { version: string; threshold: number; ownerCount: number }
+    >;
+  }> {
+    const url = `${this.baseUrl}/v2/safe-deployments?address=${encodeURIComponent(
+      address,
+    )}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      credentials: 'omit',
+      signal: AbortSignal.timeout(this.defaultTimeout),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Mai API request failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as {
+      address: string;
+      deployedOn: number[];
+      unknown: number[];
+      details: Record<
+        number,
+        { version: string; threshold: number; ownerCount: number }
+      >;
+    };
+  }
+
   /** Editor-only: unhide a previously hidden comment. */
   async unhideQipComment(req: ModerationRequest): Promise<ModerationResponse> {
     return this.commentsResultRequest<ModerationResponse>(

--- a/src/services/maiApiClient.ts
+++ b/src/services/maiApiClient.ts
@@ -326,6 +326,15 @@ export class MaiAPIClient {
   /**
    * Fire a JSON request and throw on any non-2xx — used for the auth
    * endpoints where every failure is fatal to the flow.
+   *
+   * Uses credentials: 'omit' because the API responds with
+   * Access-Control-Allow-Origin: *, which Chrome refuses to honor for
+   * credentialed cross-origin requests (response is dropped with
+   * net::ERR_FAILED). The verify response body returns the bearer token,
+   * which is the primary auth mechanism; the Set-Cookie returned alongside
+   * is only useful for same-origin deployments. Same-origin browsers can
+   * still use cookies with `credentials: 'same-origin'` (the default), but
+   * cross-origin must rely on the Bearer header.
    */
   private async commentsJsonRequest<T>(
     method: string,
@@ -338,7 +347,7 @@ export class MaiAPIClient {
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },
-      credentials: 'include',
+      credentials: 'omit',
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(this.defaultTimeout),
     });
@@ -381,12 +390,15 @@ export class MaiAPIClient {
       headers.Authorization = `Bearer ${sessionToken}`;
     }
 
+    // credentials: 'omit' — see commentsJsonRequest above for why this
+    // matters cross-origin against `Access-Control-Allow-Origin: *`. Bearer
+    // is the cross-origin auth path; same-origin clients can switch to
+    // 'same-origin' (the default) for a cookie path if/when we land
+    // origin-specific CORS.
     const response = await fetch(`${this.baseUrl}${path}`, {
       method,
       headers,
-      // Bearer wins when present — don't also send the cookie. Cookie
-      // travels only when no token is supplied (same-origin path).
-      credentials: sessionToken ? 'omit' : 'include',
+      credentials: 'omit',
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(this.defaultTimeout),
     });

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -1,0 +1,109 @@
+/**
+ * QIP comment API contract types.
+ *
+ * These mirror the public response shape produced by the comments API on the
+ * Mai API service. Internal-only fields (sig, sigSchemaVersion,
+ * strategiesJson) are deliberately omitted from the consumer-facing surface
+ * — they are forward-compatibility columns for the EIP-712 verifier path
+ * and must not be relied on by the frontend yet.
+ */
+
+/** A single comment, as returned by GET /v2/comments and POST /v2/comments. */
+export interface Comment {
+  id: number;
+  qciId: number;
+  /** Mirror of the QIP number once a QCI graduates to a Snapshot proposal. */
+  qipNumber: number | null;
+  /** Lowercase 0x-prefixed 42-char address. */
+  author: string;
+  /** Markdown body. Untrusted UGC — render through SafeMarkdown only. */
+  body: string;
+  /** Reserved for future threading; always null in v1. */
+  parentCommentId: number | null;
+
+  /** Vote-power evidence captured at write time (nullable while Option D is dormant). */
+  snapshotBlock: number | null;
+  vpAtPost: string | null;
+  strategiesHash: string | null;
+
+  /** Soft-delete columns — populated when an editor hides the comment. */
+  hiddenAt: string | null;
+  hiddenBy: string | null;
+  hiddenReason: string | null;
+
+  createdAt: string;
+
+  /** Server-resolved ENS primary name; null when no ENS is registered. */
+  ensName: string | null;
+}
+
+/** GET /v2/comments?qciId=&limit=&before= */
+export interface CommentListResponse {
+  comments: Comment[];
+  /** Cursor for the next page; null when no more rows. */
+  nextBefore: number | null;
+}
+
+export interface ListCommentsOptions {
+  qciId: number;
+  limit?: number;
+  before?: number;
+  /** Optional bearer for authenticated reads. Public reads work without a token. */
+  sessionToken?: string;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Auth — SIWE nonce + verify
+   ───────────────────────────────────────────────────────── */
+
+export interface NonceResponse {
+  nonce: string;
+  expiresAt: string;
+}
+
+export interface VerifyRequest {
+  message: string;
+  signature: string;
+}
+
+export interface VerifyResponse {
+  ok: true;
+  address: string;
+  expiresAt: string;
+  /** Plaintext bearer token. Returned once; never persisted to disk client-side. */
+  token: string;
+}
+
+/* ─────────────────────────────────────────────────────────
+   POST /v2/comments — discriminated result
+   ───────────────────────────────────────────────────────── */
+
+export interface PostCommentRequest {
+  qciId: number;
+  body: string;
+  /** Optional override; defaults to the cookie-borne session if omitted. */
+  sessionToken?: string;
+}
+
+export type PostCommentResponse =
+  | { ok: true; comment: Comment }
+  | { ok: false; status: 401; error: string }
+  | { ok: false; status: 403; error: "vp_below_threshold"; threshold: string; currentVp: string }
+  | { ok: false; status: 413; error: "body_too_large"; maxBytes: number }
+  | { ok: false; status: 429; error: "rate_limited" }
+  | { ok: false; status: 503; error: "vp_scoring_unavailable" | "vp_threshold_misconfigured" | "vp_value_unparseable"; cause?: string }
+  | { ok: false; status: 400 | 500; error: string };
+
+/* ─────────────────────────────────────────────────────────
+   Moderation — POST /v2/comments/:id/{hide,unhide}
+   ───────────────────────────────────────────────────────── */
+
+export interface ModerationRequest {
+  commentId: number;
+  reason?: string;
+  sessionToken?: string;
+}
+
+export type ModerationResponse =
+  | { ok: true; commentId: number; actionId: number }
+  | { ok: false; status: 401 | 403 | 404 | 409 | 400 | 500; error: string };

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -69,6 +69,18 @@ export const queryKeys = {
   // Status queries
   allStatuses: (registryAddress: string | undefined) =>
     ['statuses', registryAddress] as const,
+
+  // QIP comments — infinite list of visible comments per QCI
+  qipComments: (qciId: number) =>
+    ['qip-comments', qciId] as const,
+
+  // EDITOR_ROLE bytes32 hash on a specific registry (one shot, infinite TTL)
+  qipCommentsEditorRoleHash: (registryAddress: string | undefined) =>
+    ['qip-comments', 'editor-role-hash', registryAddress] as const,
+
+  // hasRole(EDITOR_ROLE, address) on a specific registry
+  qipCommentsIsEditor: (registryAddress: string | undefined, address: string | undefined) =>
+    ['qip-comments', 'is-editor', registryAddress, address?.toLowerCase()] as const,
 } as const;
 
 /**
@@ -91,4 +103,7 @@ export const queryKeyPatterns = {
   
   // Invalidate all pages
   allPages: ['qcis-page'] as const,
+
+  // Invalidate every QIP-comments query (list pages, editor role, etc.)
+  allQipComments: ['qip-comments'] as const,
 } as const;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/((?!assets/).*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the QIP-comments UI: vote-power-gated comments mounted at the bottom of every QCI detail page. Users can sign in with any wallet on any of `qidao.eth`'s supported chains (mainnet, optimism, gnosis, polygon, base, arbitrum) — including Safe smart-accounts via EIP-1271 — and post markdown comments. Editors get a hide/unhide menu. Pairs with the matching `mai-api` PR.

## What's new

### Comments surface (`src/components/Comments/`)
- `index.tsx` — composes the surface (login button → composer → list)
- `SiweLoginButton.tsx` — wallet connect + SIWE sign-in via `useSiweSession`
- `CommentComposer.tsx` — markdown textarea with live byte counter (UTF-8) capped at `VITE_QIP_COMMENTS_BODY_MAX_BYTES`
- `CommentList.tsx` — infinite-scrolling list via `useInfiniteQuery`
- `SafeMarkdown.tsx` — `react-markdown` with `urlTransform` allowlist (`http`/`https`/`mailto` only) and image rendering disabled
- `ModerationMenu.tsx` — editor-only hide/unhide with optimistic UI rollback on failure
- `CommentSkeleton.tsx` — loading affordance

### Hooks (`src/hooks/`)
- `useSiweSession.ts` — wagmi → SIWE → `verifyQipCommentSignature` → in-memory bearer token. Module-level singleton via `useSyncExternalStore` so siblings see the same session
- `useComments.ts` — paginated comment list with optimistic post + rollback
- `useIsEditor.ts` — on-chain editor-role check, cached

### Plumbing
- `src/services/maiApiClient.ts` — extended with comment + auth methods; uses `credentials: 'omit'` on all comment fetch paths so cross-origin Bearer auth works (the Vercel preview is a separate origin from mai-api)
- `src/types/comments.ts` — request/response contract types
- `src/utils/queryKeys.ts` — TanStack Query key factory entries

### Multi-chain SIWE — Safes on any `qidao.eth` chain

`src/config/chains.ts` now mirrors Snapshot's `qidao.eth` voting matrix instead of being Base-only, so any wallet that can vote on a proposal can sign in to comments. `src/providers/Web3Provider.tsx` wires `http()` transports for each chain (with optional `VITE_<NAME>_RPC_URL` overrides) and keeps `enforceSupportedChains: true` against the broader allowlist; `initialChainId` stays Base because non-comments routes (QCI registry reads) still want Base.

`src/hooks/useSiweSession.ts` reads `useChainId()` from wagmi and embeds the wallet's actual chain in the SIWE message. For EOAs the chainId is informational, but for Safes it's load-bearing — the verifier picks a per-chain RPC by `message.chainId` so EIP-1271 `isValidSignature` lands on the chain where the smart-account contract code lives.

## Mounting

`src/pages/QCIDetail.tsx` mounts `<Comments qciId={qciData.qciNumber} />` once the proposal data loads. No QCI page renders the comments surface before the proposal body is ready.

## Vercel rewrites

`vercel.json` adds a single rewrite: everything except `/assets/*` falls through to `/index.html` so direct navigation to client-side routes (`/qcis/<n>`, `/all-proposals`, etc.) doesn't 404. `/assets/*` deliberately keeps 404'ing so build issues are still surfaced.

## Environment

```
# Existing
VITE_BASE_RPC_URL=
VITE_USE_MAI_API=true
VITE_MAI_API_URL=

# New: optional per-chain RPC overrides for the multi-chain support list.
# Empty falls through to viem's chain-default public RPC.
VITE_BASE_SEPOLIA_RPC_URL=
VITE_MAINNET_RPC_URL=
VITE_OPTIMISM_RPC_URL=
VITE_GNOSIS_RPC_URL=
VITE_POLYGON_RPC_URL=
VITE_ARBITRUM_RPC_URL=

# New: must agree with the API's QIP_COMMENTS_BODY_MAX_BYTES
VITE_QIP_COMMENTS_BODY_MAX_BYTES=8192
```

## Test plan

- [x] `bun run build` clean
- [x] `bun tsc --noEmit` clean
- [x] Live preview signs in with an EOA on Base and posts a comment
- [x] SPA routing: direct nav to `/qcis/<n>` returns 200 + renders the QCI page
- [ ] Cross-chain Safe smoke on Polygon preview (requires mai-api `QIP_COMMENTS_RPC_URL_137` set)
- [ ] Editor moderation hide/unhide round-trip
