### PR TITLE
perf(rpc): Tune Base RPC pool — disable rank, persist endpoint health, prune defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^3.3.3",
         "tailwindcss-animate": "^1.0.7",
-        "viem": "2.x",
+        "viem": "~2.30.0",
         "wagmi": "^2.15.5",
       },
       "devDependencies": {
@@ -60,9 +60,11 @@
         "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^4.6.0",
         "dotenv": "^17.2.0",
+        "happy-dom": "^20.9.0",
         "react-router-dom": "^7.7.0",
         "typescript": "^5.1.6",
         "vite": "^7.0.4",
+        "vitest": "^2",
       },
     },
   },
@@ -75,6 +77,8 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
     "@assemblyscript/loader": ["@assemblyscript/loader@0.9.4", "", {}, "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="],
 
@@ -121,6 +125,16 @@
     "@babel/types": ["@babel/types@7.27.3", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw=="],
 
     "@coinbase/wallet-sdk": ["@coinbase/wallet-sdk@4.3.0", "", { "dependencies": { "@noble/hashes": "^1.4.0", "clsx": "^1.2.1", "eventemitter3": "^5.0.1", "preact": "^10.24.2" } }, "sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.3", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-tapn6XhOueMwht3E2UzY0ZZjYokdaw9XtL9kEyjhQ/Fb9vL9xTFbOaI+fV0AWvTpYu4BNloC6getKW6NtSg4mA=="],
 
@@ -622,9 +636,27 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.6.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.19", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
     "@wagmi/connectors": ["@wagmi/connectors@5.8.4", "", { "dependencies": { "@coinbase/wallet-sdk": "4.3.0", "@metamask/sdk": "0.32.0", "@safe-global/safe-apps-provider": "0.18.6", "@safe-global/safe-apps-sdk": "9.1.0", "@walletconnect/ethereum-provider": "2.21.1", "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3" }, "peerDependencies": { "@wagmi/core": "2.17.2", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-WuDH6GMDc/wbWhCcpLvUFglN/ANXht9wXD8M3rvYPGBYcuvDOOh7eXGHaDqVUpgJLcvvy0WWkTuesNbK8FCayQ=="],
 
@@ -684,6 +716,8 @@
 
     "aes-js": ["aes-js@3.0.0", "", {}, "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "ajv-errors": ["ajv-errors@3.0.0", "", { "peerDependencies": { "ajv": "^8.0.1" } }, "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ=="],
@@ -708,7 +742,11 @@
 
     "arrify": ["arrify@1.0.1", "", {}, "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "async-mutex": ["async-mutex@0.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
@@ -756,6 +794,8 @@
 
     "bufferutil": ["bufferutil@4.0.9", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw=="],
 
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -778,6 +818,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -785,6 +827,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -803,6 +847,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
@@ -832,7 +878,11 @@
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
@@ -844,13 +894,19 @@
 
     "decamelize-keys": ["decamelize-keys@1.1.1", "", { "dependencies": { "decamelize": "^1.1.0", "map-obj": "^1.0.0" } }, "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg=="],
 
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
     "decode-named-character-reference": ["decode-named-character-reference@1.1.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w=="],
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -898,6 +954,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "err-code": ["err-code@3.0.1", "", {}, "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="],
 
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
@@ -906,7 +964,11 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-toolkit": ["es-toolkit@1.33.0", "", {}, "sha512-X13Q/ZSc+vsO1q600bvNK4bxgXMkHcf//RxCmYDaRY5DAcT+eoXjY5hoAPGMdRnWQjvyLEcyauG3b6hz76LNqg=="],
 
@@ -919,6 +981,8 @@
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "eth-block-tracker": ["eth-block-tracker@7.1.0", "", { "dependencies": { "@metamask/eth-json-rpc-provider": "^1.0.0", "@metamask/safe-event-emitter": "^3.0.0", "@metamask/utils": "^5.0.1", "json-rpc-random-id": "^1.0.1", "pify": "^3.0.0" } }, "sha512-8YdplnuE1IK4xfqpf4iU7oBxnOYAc35934o083G8ao+8WM8QQtt/mVlAY6yIAdY1eMeLqg4Z//PZjJGmWGPMRg=="],
 
@@ -939,6 +1003,8 @@
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -971,6 +1037,8 @@
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
 
@@ -1014,6 +1082,8 @@
 
     "hamt-sharding": ["hamt-sharding@2.0.1", "", { "dependencies": { "sparse-array": "^1.3.1", "uint8arrays": "^3.0.0" } }, "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA=="],
 
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 
     "has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
@@ -1040,7 +1110,15 @@
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
 
@@ -1096,6 +1174,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
@@ -1125,6 +1205,8 @@
     "js-sha3": ["js-sha3@0.8.0", "", {}, "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@25.0.1", "", { "dependencies": { "cssstyle": "^4.1.0", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -1199,6 +1281,8 @@
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lossless-json": ["lossless-json@4.1.0", "", {}, "sha512-DgoRs42jH/yNubp8iinRqvG0xn5awHKXVY+7lGYjBaByoHGZt/Dz5Jkaf5znP2XHbTnAA+bbkhK3lMIaf3+92A=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1308,6 +1392,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
@@ -1366,6 +1454,8 @@
 
     "normalize-range": ["normalize-range@0.1.2", "", {}, "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="],
 
+    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
+
     "obj-multiplex": ["obj-multiplex@1.0.0", "", { "dependencies": { "end-of-stream": "^1.4.0", "once": "^1.4.0", "readable-stream": "^2.3.3" } }, "sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -1394,6 +1484,8 @@
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1401,6 +1493,10 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1542,6 +1638,8 @@
 
     "rollup": ["rollup@4.45.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.45.1", "@rollup/rollup-android-arm64": "4.45.1", "@rollup/rollup-darwin-arm64": "4.45.1", "@rollup/rollup-darwin-x64": "4.45.1", "@rollup/rollup-freebsd-arm64": "4.45.1", "@rollup/rollup-freebsd-x64": "4.45.1", "@rollup/rollup-linux-arm-gnueabihf": "4.45.1", "@rollup/rollup-linux-arm-musleabihf": "4.45.1", "@rollup/rollup-linux-arm64-gnu": "4.45.1", "@rollup/rollup-linux-arm64-musl": "4.45.1", "@rollup/rollup-linux-loongarch64-gnu": "4.45.1", "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1", "@rollup/rollup-linux-riscv64-gnu": "4.45.1", "@rollup/rollup-linux-riscv64-musl": "4.45.1", "@rollup/rollup-linux-s390x-gnu": "4.45.1", "@rollup/rollup-linux-x64-gnu": "4.45.1", "@rollup/rollup-linux-x64-musl": "4.45.1", "@rollup/rollup-win32-arm64-msvc": "4.45.1", "@rollup/rollup-win32-ia32-msvc": "4.45.1", "@rollup/rollup-win32-x64-msvc": "4.45.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw=="],
 
+    "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -1549,6 +1647,10 @@
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
@@ -1569,6 +1671,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -1606,9 +1710,13 @@
 
     "stable": ["stable@0.1.8", "", {}, "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "starknet": ["starknet@6.24.1", "", { "dependencies": { "@noble/curves": "1.7.0", "@noble/hashes": "1.6.0", "@scure/base": "1.2.1", "@scure/starknet": "1.1.0", "abi-wan-kanabi": "^2.2.3", "fetch-cookie": "~3.0.0", "isomorphic-fetch": "~3.0.0", "lossless-json": "^4.0.1", "pako": "^2.0.4", "starknet-types-07": "npm:@starknet-io/types-js@^0.7.10", "ts-mixer": "^6.0.3" } }, "sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg=="],
 
     "starknet-types-07": ["@starknet-io/types-js@0.7.10", "", {}, "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
 
@@ -1646,6 +1754,8 @@
 
     "swr": ["swr@2.3.3", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
     "tailwindcss": ["tailwindcss@3.4.17", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.6", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og=="],
@@ -1664,13 +1774,27 @@
 
     "thread-stream": ["thread-stream@0.15.2", "", { "dependencies": { "real-require": "^0.1.0" } }, "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -1744,15 +1868,25 @@
 
     "vite": ["vite@7.0.4", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.6", "picomatch": "^4.0.2", "postcss": "^8.5.6", "rollup": "^4.40.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA=="],
 
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "wagmi": ["wagmi@2.15.5", "", { "dependencies": { "@wagmi/connectors": "5.8.4", "@wagmi/core": "2.17.2", "use-sync-external-store": "1.4.0" }, "peerDependencies": { "@tanstack/react-query": ">=5.0.0", "react": ">=18", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-1l4DvaXXh2bBbKJbeoLsHkWyWA7hYuts2SDSGQU8gT37Sqzh3u8vBAwc0pN4570oGQxYVw2+YiwpR2yGPFyQTg=="],
 
     "webextension-polyfill": ["webextension-polyfill@0.10.0", "", {}, "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="],
 
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1760,13 +1894,19 @@
 
     "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
 
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.0.0", "", {}, "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="],
 
@@ -1787,6 +1927,8 @@
     "zustand": ["zustand@5.0.0", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@coinbase/wallet-sdk/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
@@ -1910,6 +2052,10 @@
 
     "cids/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
 
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "data-urls/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "decamelize-keys/map-obj": ["map-obj@1.0.1", "", {}, "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg=="],
 
     "elliptic/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
@@ -1936,9 +2082,15 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fetch-cookie/tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+
     "hamt-sharding/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+
+    "jsdom/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "jsdom/ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
 
     "json-rpc-engine/@metamask/safe-event-emitter": ["@metamask/safe-event-emitter@2.0.0", "", {}, "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="],
 
@@ -1958,11 +2110,15 @@
 
     "multihashing-async/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
 
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "normalize-package-data/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -1990,15 +2146,19 @@
 
     "tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
-    "tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
-
     "unstorage/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "unstorage/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "valtio/use-sync-external-store": ["use-sync-external-store@1.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="],
 
+    "viem/ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
+
     "vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "wagmi/use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
 
@@ -2060,7 +2220,13 @@
 
     "ethereum-cryptography/@scure/bip39/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 
+    "fetch-cookie/tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
+
     "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "obj-multiplex/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -2073,6 +2239,14 @@
     "styled-components/@emotion/is-prop-valid/@emotion/memoize": ["@emotion/memoize@0.9.0", "", {}, "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite-node/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vitest/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
@@ -2129,6 +2303,98 @@
     "@walletconnect/utils/viem/ox/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
     "abi-wan-kanabi/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "test": "node node_modules/vitest/vitest.mjs run",
+    "test:watch": "node node_modules/vitest/vitest.mjs",
     "clean": "rm -rf dist",
     "deploy:contracts": "forge script script/Deploy.s.sol --rpc-url $BASE_RPC_URL --broadcast",
     "deploy:production": "./scripts/deploy-production.sh",
@@ -80,8 +82,10 @@
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.6.0",
     "dotenv": "^17.2.0",
+    "happy-dom": "^20.9.0",
     "react-router-dom": "^7.7.0",
     "typescript": "^5.1.6",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^2"
   }
 }

--- a/src/providers/Web3Provider.tsx
+++ b/src/providers/Web3Provider.tsx
@@ -12,28 +12,43 @@ import { queryKeys } from "../utils/queryKeys";
 import { QCIClient } from "../services/qciClient";
 import { ALL_STATUS_NAMES, ALL_STATUS_HASHES } from "../config/statusConfig";
 import { buildChainTransport, buildLazyChainTransport } from "../utils/rpcPools";
-import { attachDebugGlobal } from "../utils/rpcObservability";
+import { attachDebugGlobal, hydrate as hydrateRpcHealth } from "../utils/rpcObservability";
 import { RpcStatusBanner } from "../components/RpcStatusBanner";
+
+// Canonical module-init boot order (per plan 2026-05-18-001):
+//
+//   1. hydrateRpcHealth() — reads persisted endpoint-health from localStorage
+//      and seeds in-memory terminal states + restarts F10 recovery timers.
+//      Must run BEFORE buildChainTransport so the composition-time filter in
+//      buildChainTransport sees the hydrated denied set.
+//   2. attachDebugGlobal() — exposes window.__qipsRpc, populated by the
+//      already-hydrated state.
+//   3. const transports = { ... buildChainTransport(...) ... } — composes
+//      pools with denied endpoints filtered out.
+//
+// Statement order in this file IS the execution order at module load.
+hydrateRpcHealth();
+attachDebugGlobal();
 
 // Get chains from config
 const chains = getChains();
 
 // Transports — every chain (except the localBaseFork dev shim) flows through
 // buildChainTransport, which returns a memoized viem.fallback per chainId
-// with rank-based health probing, Retry-After honoring via per-http retry,
-// and observability hooks. Chains here MUST stay in sync with
-// src/config/chains.ts; missing entries silently break wagmi reads on that
-// chain. The localBaseFork shim shares base.id, so passing
-// { rpcUrlOverride: config.baseRpcUrl } gives the local Anvil flow a single-
-// endpoint transport without the pool/observability overhead.
+// with Retry-After honoring via per-http retry and observability hooks.
+// Chains here MUST stay in sync with src/config/chains.ts; missing entries
+// silently break wagmi reads on that chain. The localBaseFork shim shares
+// base.id, so passing { rpcUrlOverride: config.baseRpcUrl } gives the local
+// Anvil flow a single-endpoint transport without the pool/observability
+// overhead.
 //
 // Base is the QCI registry chain and is always touched on initial load, so it
 // uses the eager `buildChainTransport`. The other chains are only read when
 // the user's wallet switches to them or a multi-chain view needs them, so
-// they use `buildLazyChainTransport` to defer viem's fallback rank scheduler
-// until first use. Without lazy init these chains fire ~6 probe requests each
-// within a second of page load — ~40 wasted RPCs that contribute nothing to
-// the QCI list rendering.
+// they use `buildLazyChainTransport` to defer viem.fallback construction
+// (and its observability registration) until first use. Without lazy init
+// these chains' transports would be constructed at module load even though
+// the page never touches them.
 const transports = {
   [localBaseFork.id]: http(config.baseRpcUrl),
   [base.id]: buildChainTransport(base.id),
@@ -44,9 +59,6 @@ const transports = {
   [polygon.id]: buildLazyChainTransport(polygon.id),
   [arbitrum.id]: buildLazyChainTransport(arbitrum.id),
 };
-
-// Attach window.__qipsRpc in dev so console-level debugging works.
-attachDebugGlobal();
 
 // Wagmi configuration
 const wagmiConfig = createConfig({

--- a/src/utils/poolEndpoints.ts
+++ b/src/utils/poolEndpoints.ts
@@ -1,0 +1,190 @@
+import {
+  arbitrum,
+  base,
+  baseSepolia,
+  gnosis,
+  mainnet,
+  optimism,
+  polygon,
+} from "viem/chains";
+
+/**
+ * Per-chain RPC endpoint defaults, ordered most-trusted-first.
+ *
+ * Curated from chainlist (DefiLlama/chainlist's `extraRpcs.js`) with these filters:
+ *   - https only (no wss for now — websocket transport is deferred)
+ *   - no embedded API keys (`/<32-hex-chars>` patterns, `?api_key=`, etc.)
+ *   - no `tracking: "yes"` providers (Tenderly, Tatum, Lava, Numa, BloxRoute) —
+ *     they harvest operator data
+ *   - no Alchemy/Infura `/v2/demo` URLs (rate-limit immediately)
+ *   - drop URLs we've observed failing browser CORS preflight from
+ *     `qips.qidao.localhost` (e.g., 1rpc.io/op and 1rpc.io/arb)
+ *   - **must pass browser-origin probe from `gov.mai.finance` AND
+ *     `qips.qidao.localhost`** — curl-passing endpoints often fail browser
+ *     CORS preflight; see `docs/solutions/runtime-errors/polygon-psm-rpc-401-
+ *     and-decimals-regression-2026-04-22.md`
+ *
+ * With viem's `fallback` rank scheduler DISABLED (per plan 2026-05-18-001),
+ * the input order here is the runtime order — no scoring or reranking takes
+ * place. Composition is deterministic: the first available endpoint serves;
+ * on failure, viem advances to the next in this list. Order each chain by
+ * the most reliable / lowest-latency endpoint first, with first-party
+ * endpoints relegated to last-resort positions where they are documented as
+ * rate-limited for production.
+ *
+ * Polygon defaults explicitly EXCLUDE polygon-rpc.com per the
+ * polygon-psm-rpc-401-2026-04-22 learning.
+ *
+ * Excluded from Base defaults (must not be re-added without a fresh
+ * browser-origin probe):
+ *   - https://base.llamarpc.com  — CORS preflight stalls ~10s before aborting
+ *     from browser origins; consistently observed in chrome-devtools profiling
+ *   - https://base.api.onfinality.io/public  — 429 immediately under multicall
+ *     load (3,000 RU/min public-tier cap); see
+ *     `docs/solutions/integration-issues/qciclient-rpc-override-bypassed-pool-2026-05-08.md`
+ *
+ * To refresh from chainlist: `curl -s
+ * https://raw.githubusercontent.com/DefiLlama/chainlist/main/constants/extraRpcs.js`
+ * and apply the filters above.
+ */
+export const RPC_POOLS: Record<number, readonly string[]> = {
+  [base.id]: [
+    // Canonical Base order per plan 2026-05-18-001. publicnode + drpc are
+    // production-consensus reliable (Uniswap, gnars, Reown all place one of
+    // these first). `mainnet.base.org` is last because Base's own docs say
+    // it is "rate-limited, not designed for production workloads"
+    // (https://docs.base.org/base-chain/quickstart/connecting-to-base).
+    "https://base-rpc.publicnode.com",
+    "https://base.drpc.org",
+    "https://base-mainnet.public.blastapi.io",
+    "https://1rpc.io/base",
+    "https://base.meowrpc.com",
+    "https://base-public.nodies.app",
+    "https://mainnet.base.org",
+  ],
+  [baseSepolia.id]: [
+    "https://sepolia.base.org",
+    "https://base-sepolia-rpc.publicnode.com",
+    "https://base-sepolia.drpc.org",
+  ],
+  [mainnet.id]: [
+    "https://ethereum-rpc.publicnode.com",
+    "https://eth.drpc.org",
+    "https://eth-mainnet.public.blastapi.io",
+    "https://1rpc.io/eth",
+    "https://ethereum.public.blockpi.network/v1/rpc/public",
+    "https://eth.meowrpc.com",
+    "https://ethereum-public.nodies.app",
+  ],
+  [polygon.id]: [
+    "https://polygon.drpc.org",
+    "https://polygon-bor-rpc.publicnode.com",
+    "https://1rpc.io/matic",
+    "https://polygon-public.nodies.app",
+  ],
+  [optimism.id]: [
+    "https://mainnet.optimism.io",
+    "https://optimism-rpc.publicnode.com",
+    "https://optimism.drpc.org",
+    "https://optimism.public.blockpi.network/v1/rpc/public",
+    "https://optimism-public.nodies.app",
+  ],
+  [arbitrum.id]: [
+    "https://arb1.arbitrum.io/rpc",
+    "https://arbitrum-one-rpc.publicnode.com",
+    "https://arbitrum.drpc.org",
+    "https://arbitrum-one.public.blastapi.io",
+    "https://arbitrum.public.blockpi.network/v1/rpc/public",
+    "https://arbitrum-one-public.nodies.app",
+    "https://arbitrum.meowrpc.com",
+  ],
+  [gnosis.id]: [
+    "https://rpc.gnosischain.com",
+    "https://gnosis-rpc.publicnode.com",
+    "https://gnosis.drpc.org",
+    "https://1rpc.io/gnosis",
+    "https://gnosis-public.nodies.app",
+  ],
+};
+
+const ENV_KEY_BY_CHAIN_ID: Record<number, { single: string; list: string }> = {
+  [base.id]: { single: "VITE_BASE_RPC_URL", list: "VITE_BASE_RPC_URLS" },
+  [baseSepolia.id]: {
+    single: "VITE_BASE_SEPOLIA_RPC_URL",
+    list: "VITE_BASE_SEPOLIA_RPC_URLS",
+  },
+  [mainnet.id]: { single: "VITE_MAINNET_RPC_URL", list: "VITE_MAINNET_RPC_URLS" },
+  [polygon.id]: { single: "VITE_POLYGON_RPC_URL", list: "VITE_POLYGON_RPC_URLS" },
+  [optimism.id]: {
+    single: "VITE_OPTIMISM_RPC_URL",
+    list: "VITE_OPTIMISM_RPC_URLS",
+  },
+  [arbitrum.id]: {
+    single: "VITE_ARBITRUM_RPC_URL",
+    list: "VITE_ARBITRUM_RPC_URLS",
+  },
+  [gnosis.id]: { single: "VITE_GNOSIS_RPC_URL", list: "VITE_GNOSIS_RPC_URLS" },
+};
+
+function readEnv(key: string): string | undefined {
+  // Mirrors src/config/env.ts:getEnvVar exactly. The optional-chaining variant
+  // I tried first does not consistently surface VITE_* env vars in Vite's
+  // dev pipeline; the explicit typeof guard does.
+  let value: string | undefined;
+  try {
+    if (typeof import.meta !== "undefined" && (import.meta as unknown as { env?: Record<string, string> }).env) {
+      value = (import.meta as unknown as { env: Record<string, string> }).env[key];
+    }
+  } catch {
+    // import.meta is unavailable in some SSR / test contexts.
+  }
+  if (!value && typeof process !== "undefined" && process.env?.[key]) {
+    value = process.env[key];
+  }
+  if (typeof value === "string" && value.length > 0) return value;
+  return undefined;
+}
+
+function readBoolEnv(key: string): boolean {
+  return readEnv(key) === "true";
+}
+
+/**
+ * Resolve the endpoint list for a chain.
+ *
+ * Precedence (top wins):
+ *   1. VITE_<CHAIN>_RPC_URLS (comma-split list).
+ *   2. VITE_<CHAIN>_RPC_URL (single override; treated as a strict one-element
+ *      pool, NOT appended to defaults).
+ *   3. RPC_POOLS[chainId] defaults.
+ *
+ * Local-mode short-circuit: when VITE_LOCAL_MODE=true and the singular
+ * VITE_BASE_RPC_URL points at localhost, return only that one URL for base.id
+ * regardless of the pool. Preserves the Anvil fork pattern.
+ */
+export function getPoolEndpoints(chainId: number): string[] {
+  const envKeys = ENV_KEY_BY_CHAIN_ID[chainId];
+  const localMode = readBoolEnv("VITE_LOCAL_MODE");
+  const singleBaseRpc = readEnv("VITE_BASE_RPC_URL");
+  if (
+    chainId === base.id &&
+    localMode &&
+    singleBaseRpc &&
+    (singleBaseRpc.includes("localhost") || singleBaseRpc.includes("127.0.0.1"))
+  ) {
+    return [singleBaseRpc];
+  }
+  if (envKeys) {
+    const list = readEnv(envKeys.list);
+    if (list) {
+      return list
+        .split(",")
+        .map((url) => url.trim())
+        .filter(Boolean);
+    }
+    const single = readEnv(envKeys.single);
+    if (single) return [single];
+  }
+  const defaults = RPC_POOLS[chainId];
+  return defaults ? [...defaults] : [];
+}

--- a/src/utils/rpcObservability.test.ts
+++ b/src/utils/rpcObservability.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { base } from "viem/chains";
+import {
+  __resetForTests,
+  dehydrate,
+  flushDehydrateForTests,
+  getDeniedEndpointsForChain,
+  getSnapshot,
+  hydrate,
+  observabilityHandle,
+  recordAuthRejected,
+  recordCorsBlocked,
+  recordResponse,
+} from "./rpcObservability";
+
+const PERSIST_KEY = "qips:rpc-health:v1";
+
+// Must be a URL present in RPC_POOLS[base.id] so the hash-validated
+// hydration path can recognise it.
+const BASE_URL = "https://base-rpc.publicnode.com";
+
+const registerBase = (urls: readonly string[] = [BASE_URL]) =>
+  observabilityHandle.register(base.id, {
+    endpoints: urls,
+    probeEndpoint: vi.fn(async () => undefined),
+  });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z"));
+  if (typeof window !== "undefined" && window.localStorage) window.localStorage.clear();
+  __resetForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("rpcObservability persistence", () => {
+  describe("dehydrate / hydrate round-trip", () => {
+    it("persists a terminal cors-blocked entry and restores it on the next session", () => {
+      registerBase();
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+
+      // Reset only in-memory state — leave localStorage intact.
+      __resetForTests({ keepStorage: true });
+      registerBase();
+      hydrate();
+
+      const restored = getSnapshot()[base.id]?.[BASE_URL];
+      expect(restored?.state).toBe("cors-blocked");
+      expect(restored?.demotedAt).toBeDefined();
+    });
+  });
+
+  describe("TTL gating", () => {
+    it("does NOT restore a cors-blocked entry older than 1h (terminal TTL)", () => {
+      registerBase();
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+
+      __resetForTests({ keepStorage: true });
+      vi.setSystemTime(Date.now() + 90 * 60 * 1000); // 90 min later
+      registerBase();
+      hydrate();
+
+      const restored = getSnapshot()[base.id]?.[BASE_URL];
+      expect(restored).toBeUndefined();
+      expect(getDeniedEndpointsForChain(base.id).size).toBe(0);
+    });
+
+    it("DOES restore a healthy entry within 24h (positive TTL)", () => {
+      registerBase();
+      recordResponse(base.id, BASE_URL, { ok: true, status: 200 });
+      flushDehydrateForTests();
+
+      __resetForTests({ keepStorage: true });
+      vi.setSystemTime(Date.now() + 12 * 60 * 60 * 1000); // 12h later
+      registerBase();
+      hydrate();
+
+      const restored = getSnapshot()[base.id]?.[BASE_URL];
+      expect(restored?.state).toBe("healthy");
+    });
+
+    it("drops the whole blob when its overall ts exceeds 24h", () => {
+      registerBase();
+      recordResponse(base.id, BASE_URL, { ok: true, status: 200 });
+      flushDehydrateForTests();
+
+      __resetForTests({ keepStorage: true });
+      vi.setSystemTime(Date.now() + 25 * 60 * 60 * 1000); // 25h later
+      registerBase();
+      hydrate();
+
+      expect(getSnapshot()[base.id]?.[BASE_URL]).toBeUndefined();
+    });
+  });
+
+  describe("pool-hash invalidation", () => {
+    it("drops the persisted blob when the current pool composition no longer matches", () => {
+      registerBase();
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+
+      // Tamper the persisted blob's poolHash to simulate a future deploy
+      // that edited RPC_POOLS — the hash will no longer match.
+      const raw = window.localStorage.getItem(PERSIST_KEY);
+      expect(raw).not.toBeNull();
+      const blob = JSON.parse(raw!);
+      blob.poolHash = "stale-hash-from-a-previous-deploy";
+      window.localStorage.setItem(PERSIST_KEY, JSON.stringify(blob));
+
+      __resetForTests({ keepStorage: true });
+      registerBase();
+      hydrate();
+
+      expect(getSnapshot()[base.id]?.[BASE_URL]).toBeUndefined();
+      expect(window.localStorage.getItem(PERSIST_KEY)).toBeNull();
+    });
+  });
+
+  describe("denied endpoint set", () => {
+    it("includes cors-blocked URLs", () => {
+      registerBase();
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      const denied = getDeniedEndpointsForChain(base.id);
+      expect(denied.has(BASE_URL)).toBe(true);
+    });
+
+    it("includes auth-rejected URLs", () => {
+      registerBase();
+      recordAuthRejected(base.id, BASE_URL, { status: 403 });
+      const denied = getDeniedEndpointsForChain(base.id);
+      expect(denied.has(BASE_URL)).toBe(true);
+    });
+
+    it("excludes cooling URLs (cooling is recoverable, not terminal)", () => {
+      registerBase();
+      recordResponse(base.id, BASE_URL, { ok: false, status: 500 });
+      const denied = getDeniedEndpointsForChain(base.id);
+      expect(denied.has(BASE_URL)).toBe(false);
+    });
+  });
+
+  describe("hydration drops stale URLs no longer in the pool", () => {
+    it("does not restore an entry whose URL is absent from RPC_POOLS for that chain", () => {
+      // Persist a blob whose entries include a URL that is NOT in the
+      // current RPC_POOLS[base.id]. We do this by tampering the blob directly
+      // (recordCorsBlocked against a URL outside the pool would still write
+      // to in-memory state, but the realistic case is a deploy that REMOVED
+      // a URL from defaults while a previous session's persisted entry still
+      // references it).
+      registerBase();
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+
+      const blob = JSON.parse(window.localStorage.getItem(PERSIST_KEY)!);
+      // Inject an entry for a URL that's NOT in RPC_POOLS[base.id].
+      blob.entries[base.id]["https://removed-from-defaults.example.com"] = {
+        state: "cors-blocked",
+        demotedAt: Date.now(),
+        hadOkSample: false,
+      };
+      window.localStorage.setItem(PERSIST_KEY, JSON.stringify(blob));
+
+      __resetForTests({ keepStorage: true });
+      registerBase();
+      hydrate();
+
+      expect(getSnapshot()[base.id]?.[BASE_URL]?.state).toBe("cors-blocked");
+      expect(
+        getSnapshot()[base.id]?.["https://removed-from-defaults.example.com"],
+      ).toBeUndefined();
+    });
+  });
+
+  describe("write throttling", () => {
+    it("collapses many state changes into a single localStorage write", () => {
+      registerBase();
+      // Spy on the actual `setItem` on the polyfilled localStorage instance;
+      // `Storage.prototype` does not intercept our MemoryStorage polyfill.
+      const setItemSpy = vi.spyOn(window.localStorage, "setItem");
+
+      for (let i = 0; i < 50; i += 1) {
+        recordResponse(base.id, BASE_URL, { ok: i % 2 === 0, status: 200 });
+      }
+
+      // Within the throttle window, no writes happen.
+      expect(setItemSpy).not.toHaveBeenCalled();
+
+      // After the throttle window, exactly one write lands.
+      vi.advanceTimersByTime(1500);
+      expect(setItemSpy.mock.calls.filter(([k]) => k === PERSIST_KEY)).toHaveLength(
+        1,
+      );
+
+      setItemSpy.mockRestore();
+    });
+  });
+
+  describe("error resilience", () => {
+    it("swallows window.localStorage.setItem failures without throwing", () => {
+      registerBase();
+      const setItemSpy = vi
+        .spyOn(window.localStorage, "setItem")
+        .mockImplementation(() => {
+          throw new DOMException("QuotaExceededError", "QuotaExceededError");
+        });
+
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      expect(() => flushDehydrateForTests()).not.toThrow();
+      expect(() => dehydrate()).not.toThrow();
+
+      setItemSpy.mockRestore();
+    });
+  });
+
+  describe("F10 timer restoration with elapsed demotedAt", () => {
+    it("schedules the recovery probe at (delay - elapsed) when persisted entry is mid-window", async () => {
+      const probe = vi.fn(async () => undefined);
+      observabilityHandle.register(base.id, {
+        endpoints: [BASE_URL],
+        probeEndpoint: probe,
+      });
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+
+      __resetForTests({ keepStorage: true });
+
+      // 30 min later — half of the 1h first-slot window has already elapsed.
+      vi.setSystemTime(Date.now() + 30 * 60 * 1000);
+
+      observabilityHandle.register(base.id, {
+        endpoints: [BASE_URL],
+        probeEndpoint: probe,
+      });
+      hydrate();
+
+      // After 29 more minutes the probe should NOT have fired yet.
+      await vi.advanceTimersByTimeAsync(29 * 60 * 1000);
+      expect(probe).not.toHaveBeenCalled();
+
+      // After 2 more minutes (cumulative 31 from hydrate), it should have.
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      expect(probe).toHaveBeenCalledTimes(1);
+    });
+
+    it("schedules the recovery probe immediately when persisted entry is past the final slot", async () => {
+      const probe = vi.fn(async () => undefined);
+      observabilityHandle.register(base.id, {
+        endpoints: [BASE_URL],
+        probeEndpoint: probe,
+      });
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      // Override the 1h-from-now TTL gate by using a fresh blob whose ts and
+      // demotedAt span the full F10 cumulative window. The cumulative is
+      // 1h + 6h + 24h = 31h; we need elapsed > 31h to land in the
+      // "fire immediately" branch.
+      flushDehydrateForTests();
+
+      __resetForTests({ keepStorage: true });
+
+      // 40h later — past 1h+6h+24h = 31h cumulative.
+      // Per-entry terminal TTL is 1h, so we need to bypass the hydrate TTL
+      // check by tampering ts on the persisted blob to keep the entry alive.
+      const blob = JSON.parse(window.localStorage.getItem(PERSIST_KEY)!);
+      // Pretend the blob was written 40h after the demotedAt (so age == 0
+      // at hydrate time, passing the TTL gate), but demotedAt is 40h in the
+      // past.
+      const nowAfter = Date.now() + 40 * 60 * 60 * 1000;
+      blob.ts = nowAfter;
+      blob.entries[base.id][BASE_URL].demotedAt = nowAfter - 40 * 60 * 60 * 1000;
+      window.localStorage.setItem(PERSIST_KEY, JSON.stringify(blob));
+
+      vi.setSystemTime(nowAfter);
+
+      observabilityHandle.register(base.id, {
+        endpoints: [BASE_URL],
+        probeEndpoint: probe,
+      });
+      hydrate();
+
+      // Fires within the next event loop tick (delay=0 setTimeout).
+      await vi.advanceTimersByTimeAsync(1);
+      expect(probe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("hadOkSample round-trip", () => {
+    it("preserves hadOkSample across hydration", () => {
+      registerBase();
+      // Make endpoint healthy, then promote to auth-rejected.
+      recordResponse(base.id, BASE_URL, { ok: true, status: 200 });
+      recordAuthRejected(base.id, BASE_URL, { status: 403 });
+      flushDehydrateForTests();
+
+      __resetForTests({ keepStorage: true });
+      registerBase();
+      hydrate();
+
+      const restored = getSnapshot()[base.id]?.[BASE_URL];
+      expect(restored?.state).toBe("auth-rejected");
+      expect(restored?.hadOkSample).toBe(true);
+    });
+  });
+
+  describe("__resetForTests", () => {
+    it("clears localStorage by default", () => {
+      registerBase();
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+      expect(window.localStorage.getItem(PERSIST_KEY)).not.toBeNull();
+
+      __resetForTests();
+      expect(window.localStorage.getItem(PERSIST_KEY)).toBeNull();
+    });
+
+    it("keeps localStorage when keepStorage: true", () => {
+      registerBase();
+      recordCorsBlocked(base.id, BASE_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+      expect(window.localStorage.getItem(PERSIST_KEY)).not.toBeNull();
+
+      __resetForTests({ keepStorage: true });
+      expect(window.localStorage.getItem(PERSIST_KEY)).not.toBeNull();
+    });
+  });
+});

--- a/src/utils/rpcObservability.test.ts
+++ b/src/utils/rpcObservability.test.ts
@@ -65,8 +65,12 @@ describe("rpcObservability persistence", () => {
       registerBase();
       hydrate();
 
+      // `register()` pre-seeds the URL as state="unknown" to prevent the
+      // RpcStatusBanner false-positive on cold load. The TTL-gated hydrate
+      // is verified by the state staying at "unknown" rather than being
+      // restored to "cors-blocked", AND by the denied set being empty.
       const restored = getSnapshot()[base.id]?.[BASE_URL];
-      expect(restored).toBeUndefined();
+      expect(restored?.state).toBe("unknown");
       expect(getDeniedEndpointsForChain(base.id).size).toBe(0);
     });
 
@@ -94,7 +98,9 @@ describe("rpcObservability persistence", () => {
       registerBase();
       hydrate();
 
-      expect(getSnapshot()[base.id]?.[BASE_URL]).toBeUndefined();
+      // Pre-seeded by register() as "unknown" but NOT restored to "healthy"
+      // from the expired persisted blob.
+      expect(getSnapshot()[base.id]?.[BASE_URL]?.state).toBe("unknown");
     });
   });
 
@@ -116,7 +122,9 @@ describe("rpcObservability persistence", () => {
       registerBase();
       hydrate();
 
-      expect(getSnapshot()[base.id]?.[BASE_URL]).toBeUndefined();
+      // Pre-seeded as "unknown" by register() but NOT restored to the
+      // persisted "cors-blocked" because the pool hash didn't match.
+      expect(getSnapshot()[base.id]?.[BASE_URL]?.state).toBe("unknown");
       expect(window.localStorage.getItem(PERSIST_KEY)).toBeNull();
     });
   });
@@ -303,6 +311,55 @@ describe("rpcObservability persistence", () => {
       const restored = getSnapshot()[base.id]?.[BASE_URL];
       expect(restored?.state).toBe("auth-rejected");
       expect(restored?.hadOkSample).toBe(true);
+    });
+  });
+
+  describe("RpcStatusBanner false-positive guard", () => {
+    it("registration pre-seeds unknown entries for ALL registered endpoints (prevents banner flash on cold load with persisted health)", () => {
+      // Reproduce the cold-load scenario: hydrate seeds ONE URL as cors-blocked,
+      // then buildChainTransport calls observabilityHandle.register with the
+      // full pool. Banner's deriveExhaustedFromSnapshot would false-positive
+      // if the snapshot only contained the hydrated terminal entry.
+      const BAD_URL = BASE_URL;
+      const GOOD_URLS = ["https://base.drpc.org", "https://base-mainnet.public.blastapi.io"];
+
+      // Step 1: hydrate seeds the bad URL via the real persistence path.
+      observabilityHandle.register(base.id, {
+        endpoints: [BAD_URL],
+        probeEndpoint: vi.fn(async () => undefined),
+      });
+      recordCorsBlocked(base.id, BAD_URL, new TypeError("Failed to fetch"));
+      flushDehydrateForTests();
+      __resetForTests({ keepStorage: true });
+      hydrate();
+
+      // After hydrate: only the bad URL is in the snapshot.
+      const afterHydrate = getSnapshot()[base.id];
+      expect(Object.keys(afterHydrate ?? {})).toEqual([BAD_URL]);
+
+      // Step 2: buildChainTransport calls register with the FULL pool.
+      observabilityHandle.register(base.id, {
+        endpoints: [BAD_URL, ...GOOD_URLS],
+        probeEndpoint: vi.fn(async () => undefined),
+      });
+
+      // After register: the snapshot reflects the full pool, with the good
+      // URLs as state="unknown" — banner's deriveExhaustedFromSnapshot will
+      // skip them and NOT report the chain as exhausted.
+      const afterRegister = getSnapshot()[base.id] ?? {};
+      expect(afterRegister[BAD_URL]?.state).toBe("cors-blocked");
+      for (const url of GOOD_URLS) {
+        expect(afterRegister[url]?.state).toBe("unknown");
+      }
+
+      // Simulate the banner's logic: are there only non-healthy-non-unknown
+      // states? It should be FALSE because the good URLs are unknown.
+      const urls = Object.keys(afterRegister);
+      const allDown = urls.every((url) => {
+        const s = afterRegister[url].state;
+        return s !== "healthy" && s !== "unknown";
+      });
+      expect(allDown).toBe(false);
     });
   });
 

--- a/src/utils/rpcObservability.ts
+++ b/src/utils/rpcObservability.ts
@@ -18,6 +18,7 @@
  */
 
 import { base, baseSepolia, mainnet, polygon, optimism, gnosis, arbitrum } from "viem/chains";
+import { RPC_POOLS, getPoolEndpoints } from "./poolEndpoints";
 
 export type EndpointState =
   | "unknown"
@@ -139,10 +140,11 @@ function setState(chainId: number, url: string, next: EndpointState): boolean {
   h.state = next;
   if (TERMINAL_STATES.has(next)) {
     h.demotedAt = Date.now();
-  } else if (h.state === "healthy") {
+  } else if (next === "healthy") {
     h.demotedAt = undefined;
   }
   emit("endpoint:state-change", { chainId, url, state: next });
+  scheduleDehydrate();
   return true;
 }
 
@@ -468,7 +470,7 @@ export function attachDebugGlobal(): void {
 }
 
 /** Reset module state. Test-only; not used in production. */
-export function __resetForTests(): void {
+export function __resetForTests(opts: { keepStorage?: boolean } = {}): void {
   state.chains.clear();
   state.registrations.clear();
   for (const t of state.recoveryTimers.values()) clearTimeout(t);
@@ -476,4 +478,343 @@ export function __resetForTests(): void {
   state.exhaustedChains.clear();
   state.inFlightProbes.clear();
   listeners.clear();
+  if (dehydrateTimer) {
+    clearTimeout(dehydrateTimer);
+    dehydrateTimer = null;
+  }
+  if (!opts.keepStorage && typeof window !== "undefined" && window.localStorage) {
+    try {
+      window.localStorage.removeItem(PERSIST_KEY);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// ─── Endpoint-health persistence ────────────────────────────────────────────
+//
+// Survives page loads by writing terminal-state endpoints (and recent healthy
+// ones) to localStorage. On the next session, `hydrate()` reads the blob,
+// validates it against the current pool composition (via `poolHash`), and
+// reseeds in-memory state so the cold reload skips re-discovering the same
+// bad endpoint.
+//
+// Asymmetric TTL: positive (healthy) entries live 24h; terminal entries live
+// 1h to match `AUTO_RECOVERY_DELAYS_MS[0]` so a session ending just before
+// the first F10 probe doesn't pin the endpoint as bad indefinitely.
+//
+// pool-hash invalidation: when `RPC_POOLS` or any env override changes, the
+// computed hash differs from the persisted one and the entire blob is
+// dropped. Stale URLs that survive a partial pool edit are also filtered.
+//
+// Plan: docs/plans/2026-05-18-001-fix-base-rpc-pool-tuning-plan.md
+
+const PERSIST_KEY = "qips:rpc-health:v1";
+const POSITIVE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const TERMINAL_TTL_MS = 60 * 60 * 1000; // 1h — matches AUTO_RECOVERY_DELAYS_MS[0]
+const DEHYDRATE_THROTTLE_MS = 1000;
+
+type PersistableState = "healthy" | "cors-blocked" | "auth-rejected";
+
+interface PersistedEntry {
+  state: PersistableState;
+  demotedAt?: number;
+  hadOkSample: boolean;
+}
+
+interface PersistedBlob {
+  poolHash: string;
+  ts: number;
+  entries: Record<number, Record<string, PersistedEntry>>;
+}
+
+/**
+ * cyrb53 — small, deterministic, sync 53-bit hash. MIT-licensed.
+ * Source: https://github.com/bryc/code/blob/master/jshash/hashes/cyrb53.js
+ *
+ * Cryptographic strength is unnecessary — we need "any pool edit produces a
+ * different hash," not collision resistance. SubtleCrypto.digest is async
+ * and would break the sync hydrate path.
+ */
+function cyrb53(input: string, seed = 0): string {
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  const result = 4294967296 * (2097151 & h2) + (h1 >>> 0);
+  return result.toString(16);
+}
+
+/**
+ * Compute a stable hash of the source-of-truth pool composition.
+ *
+ * Uses RPC_POOLS + env overrides via getPoolEndpoints(chainId) — NOT
+ * state.registrations, because registrations don't exist yet at hydrate
+ * time. The canonical boot order has registrations happening later, inside
+ * buildChainTransport.
+ */
+function getPoolHash(): string {
+  const chainIds = Object.keys(RPC_POOLS).map(Number).sort((a, b) => a - b);
+  const payload: Record<number, string[]> = {};
+  for (const chainId of chainIds) {
+    const endpoints = [...getPoolEndpoints(chainId)].sort();
+    payload[chainId] = endpoints;
+  }
+  return cyrb53(JSON.stringify(payload));
+}
+
+let dehydrateTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleDehydrate(): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  if (dehydrateTimer) return; // a write is already pending; final write captures latest state
+  dehydrateTimer = setTimeout(() => {
+    dehydrateTimer = null;
+    dehydrate();
+  }, DEHYDRATE_THROTTLE_MS);
+}
+
+/**
+ * Write current persistable state to localStorage. Soft-fails on quota or
+ * SSR-style absence of `localStorage`. Normally invoked via the throttled
+ * `scheduleDehydrate`; tests can call directly.
+ */
+export function dehydrate(): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    const entries: Record<number, Record<string, PersistedEntry>> = {};
+    for (const [chainId, chain] of state.chains.entries()) {
+      const inner: Record<string, PersistedEntry> = {};
+      for (const [url, h] of chain.entries()) {
+        if (
+          h.state === "healthy" ||
+          h.state === "cors-blocked" ||
+          h.state === "auth-rejected"
+        ) {
+          inner[url] = {
+            state: h.state,
+            demotedAt: h.demotedAt,
+            hadOkSample: h.hadOkSample,
+          };
+        }
+      }
+      if (Object.keys(inner).length > 0) entries[chainId] = inner;
+    }
+    const blob: PersistedBlob = {
+      poolHash: getPoolHash(),
+      ts: Date.now(),
+      entries,
+    };
+    window.localStorage.setItem(PERSIST_KEY, JSON.stringify(blob));
+  } catch {
+    // Quota errors, JSON failures — swallow. Persistence is best-effort;
+    // missing it does not break in-memory observability.
+  }
+}
+
+/**
+ * Test-only helper to synchronously flush the throttled dehydrate timer.
+ * Production paths rely on the setTimeout firing naturally.
+ */
+export function flushDehydrateForTests(): void {
+  if (dehydrateTimer) {
+    clearTimeout(dehydrateTimer);
+    dehydrateTimer = null;
+  }
+  dehydrate();
+}
+
+function isPersistedEntryShape(value: unknown): value is PersistedEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    (v.state === "healthy" ||
+      v.state === "cors-blocked" ||
+      v.state === "auth-rejected") &&
+    (v.demotedAt === undefined || typeof v.demotedAt === "number") &&
+    typeof v.hadOkSample === "boolean"
+  );
+}
+
+function isPersistedBlobShape(value: unknown): value is PersistedBlob {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.poolHash !== "string" || typeof v.ts !== "number") return false;
+  if (typeof v.entries !== "object" || v.entries === null) return false;
+  // Don't deep-validate every entry — isPersistedEntryShape gates each entry
+  // at hydrate time. Shape validation here just catches obvious corruption.
+  return true;
+}
+
+/**
+ * Restore terminal and recent-healthy endpoint state from localStorage.
+ *
+ * Canonical boot-order placement: called from `Web3Provider.tsx` at module
+ * init BEFORE `attachDebugGlobal()` and BEFORE any `buildChainTransport`,
+ * so `getDeniedEndpointsForChain` returns the seeded set when
+ * `buildChainTransport` first composes its pool.
+ *
+ * Validates: versioned key (PERSIST_KEY), shape, top-level freshness
+ * (24h cap), per-entry TTL (asymmetric), pool-hash match against current
+ * `RPC_POOLS` + env. On any failure the blob is removed and hydration is a
+ * silent no-op (this also covers private-mode browsers / quota errors).
+ */
+export function hydrate(): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(PERSIST_KEY);
+  } catch {
+    return;
+  }
+  if (!raw) return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    safeRemove();
+    return;
+  }
+  if (!isPersistedBlobShape(parsed)) {
+    safeRemove();
+    return;
+  }
+  const blob = parsed;
+
+  const now = Date.now();
+  // Top-level freshness — blobs older than POSITIVE_TTL_MS are discarded
+  // wholesale to avoid carrying ancient state forward.
+  if (now - blob.ts > POSITIVE_TTL_MS) {
+    safeRemove();
+    return;
+  }
+
+  // Pool-composition hash check — invalidate on any RPC_POOLS or env edit.
+  if (blob.poolHash !== getPoolHash()) {
+    safeRemove();
+    return;
+  }
+
+  for (const [chainIdStr, chainEntries] of Object.entries(blob.entries)) {
+    const chainId = Number(chainIdStr);
+    if (!Number.isFinite(chainId)) continue;
+    const knownUrls = new Set(getPoolEndpoints(chainId));
+
+    for (const [url, entry] of Object.entries(chainEntries)) {
+      if (!isPersistedEntryShape(entry)) continue;
+      // Stale URLs (no longer in the current pool) are silently dropped.
+      if (!knownUrls.has(url)) continue;
+
+      // Per-entry TTL.
+      const entryAge = now - blob.ts;
+      const isTerminal =
+        entry.state === "cors-blocked" || entry.state === "auth-rejected";
+      if (isTerminal && entryAge > TERMINAL_TTL_MS) continue;
+      if (!isTerminal && entryAge > POSITIVE_TTL_MS) continue;
+
+      _setStateFromHydration(chainId, url, entry);
+    }
+  }
+}
+
+function safeRemove(): void {
+  try {
+    window.localStorage.removeItem(PERSIST_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Internal: seed an endpoint's state from a persisted entry without
+ * triggering the dehydrate throttle (would cause an immediate re-write of
+ * what we just read) and, for terminal states, restart the F10 timer at
+ * the correct elapsed offset.
+ */
+function _setStateFromHydration(
+  chainId: number,
+  url: string,
+  entry: PersistedEntry,
+): void {
+  const h = ensureEndpoint(chainId, url);
+  h.state = entry.state;
+  h.hadOkSample = entry.hadOkSample;
+  if (entry.demotedAt !== undefined) h.demotedAt = entry.demotedAt;
+  // No emit, no dehydrate trigger — this is a hydration, not a transition.
+
+  if (entry.state === "cors-blocked" || entry.state === "auth-rejected") {
+    _restartF10TimerFromDemotedAt(chainId, url, entry.demotedAt ?? Date.now());
+  }
+}
+
+/**
+ * Restart the F10 auto-recovery scheduler at the slot whose cumulative delay
+ * has not yet elapsed since `demotedAt`. Clamps at 0 (fire immediately) if
+ * the entry sat past the final slot.
+ */
+function _restartF10TimerFromDemotedAt(
+  chainId: number,
+  url: string,
+  demotedAt: number,
+): void {
+  const elapsed = Math.max(0, Date.now() - demotedAt);
+  let cumulative = 0;
+  for (let idx = 0; idx < AUTO_RECOVERY_DELAYS_MS.length; idx += 1) {
+    cumulative += AUTO_RECOVERY_DELAYS_MS[idx];
+    if (elapsed < cumulative) {
+      const remaining = Math.max(0, cumulative - elapsed);
+      _scheduleAtIndexWithDelay(chainId, url, demotedAt, idx, remaining);
+      return;
+    }
+  }
+  // Past the final slot — fire immediately at the last index.
+  _scheduleAtIndexWithDelay(
+    chainId,
+    url,
+    demotedAt,
+    AUTO_RECOVERY_DELAYS_MS.length - 1,
+    0,
+  );
+}
+
+function _scheduleAtIndexWithDelay(
+  chainId: number,
+  url: string,
+  demotedAt: number,
+  attemptIndex: number,
+  delayMs: number,
+): void {
+  const key = `${chainId}::${url}`;
+  const prior = state.recoveryTimers.get(key);
+  if (prior) clearTimeout(prior);
+  const timer = setTimeout(() => {
+    runAutoRecoveryProbe(chainId, url, key, demotedAt, attemptIndex).catch((err) => {
+      console.error("[rpcObservability] auto-recovery probe threw", err);
+    });
+  }, delayMs);
+  state.recoveryTimers.set(key, timer);
+}
+
+/**
+ * URLs in terminal state for the given chain. Used by `buildChainTransport`
+ * (U5) to filter the pool composition before constructing `fallback(...)`.
+ */
+export function getDeniedEndpointsForChain(chainId: number): Set<string> {
+  const out = new Set<string>();
+  const chain = state.chains.get(chainId);
+  if (!chain) return out;
+  for (const [url, h] of chain.entries()) {
+    if (h.state === "cors-blocked" || h.state === "auth-rejected") {
+      out.add(url);
+    }
+  }
+  return out;
 }

--- a/src/utils/rpcObservability.ts
+++ b/src/utils/rpcObservability.ts
@@ -429,6 +429,17 @@ export function getSnapshot(): Record<number, Record<string, EndpointHealth>> {
 export const observabilityHandle = {
   register(chainId: number, registration: ChainRegistration): void {
     state.registrations.set(chainId, registration);
+    // Pre-seed unknown entries for all registered endpoints so the snapshot
+    // reflects the full pool the moment registration completes. Without this,
+    // when hydrate() restores a terminal entry for one URL before any other
+    // URL has been touched, the snapshot has exactly one cors-blocked entry
+    // and `deriveExhaustedFromSnapshot` in RpcStatusBanner concludes "all
+    // known endpoints are dead → pool exhausted" — producing a banner flash
+    // on every cold load with persisted health. ensureEndpoint is idempotent
+    // so already-hydrated terminal entries are unchanged.
+    for (const url of registration.endpoints) {
+      ensureEndpoint(chainId, url);
+    }
   },
   snapshotAttempted(chainId: number): { url: string; state: EndpointState; status?: number; message?: string }[] {
     const chain = state.chains.get(chainId);

--- a/src/utils/rpcPools.test.ts
+++ b/src/utils/rpcPools.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { base } from "viem/chains";
+import {
+  __resetForTests,
+  flushDehydrateForTests,
+  getDeniedEndpointsForChain,
+  hydrate,
+  observabilityHandle,
+  recordCorsBlocked,
+} from "./rpcObservability";
+import {
+  __resetTransportCacheForTests,
+  buildChainTransport,
+  getPoolEndpoints,
+} from "./rpcPools";
+
+const PERSIST_KEY = "qips:rpc-health:v1";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z"));
+  if (typeof window !== "undefined" && window.localStorage)
+    window.localStorage.clear();
+  __resetTransportCacheForTests();
+  __resetForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("buildChainTransport composition filter", () => {
+  it("constructs a transport with all default Base endpoints when nothing is denied", () => {
+    const transport = buildChainTransport(base.id);
+    expect(transport).toBeDefined();
+    // Indirect check — getPoolEndpoints is the source-of-truth list; after
+    // filter with empty denied set, the transport composes over the full list.
+    expect(getDeniedEndpointsForChain(base.id).size).toBe(0);
+    expect(getPoolEndpoints(base.id).length).toBeGreaterThan(0);
+  });
+
+  it("filters out denied endpoints when buildChainTransport is called after hydrate", () => {
+    const endpoints = getPoolEndpoints(base.id);
+    expect(endpoints.length).toBeGreaterThan(1);
+    const targetUrl = endpoints[0];
+
+    // Seed terminal state for the first endpoint.
+    observabilityHandle.register(base.id, {
+      endpoints,
+      probeEndpoint: vi.fn(async () => undefined),
+    });
+    recordCorsBlocked(base.id, targetUrl, new TypeError("Failed to fetch"));
+    flushDehydrateForTests();
+
+    __resetForTests({ keepStorage: true });
+    __resetTransportCacheForTests();
+
+    // Hydrate seeds in-memory state from localStorage.
+    hydrate();
+
+    // Build a fresh transport. The composition-time filter should now omit
+    // the denied URL from the active fallback chain.
+    const transport = buildChainTransport(base.id);
+    expect(transport).toBeDefined();
+    expect(getDeniedEndpointsForChain(base.id).has(targetUrl)).toBe(true);
+  });
+
+  it("falls back to the full pool when every endpoint is denied (R2 exception)", () => {
+    const endpoints = getPoolEndpoints(base.id);
+    observabilityHandle.register(base.id, {
+      endpoints,
+      probeEndpoint: vi.fn(async () => undefined),
+    });
+    // Deny every endpoint.
+    for (const url of endpoints) {
+      recordCorsBlocked(base.id, url, new TypeError("Failed to fetch"));
+    }
+    expect(getDeniedEndpointsForChain(base.id).size).toBe(endpoints.length);
+
+    __resetTransportCacheForTests();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    // Should construct successfully (degraded — full pool used because
+    // filtering would have left zero endpoints).
+    const transport = buildChainTransport(base.id);
+    expect(transport).toBeDefined();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("denied at compose time");
+
+    warnSpy.mockRestore();
+  });
+
+  it("respects pool-hash invalidation: a stale persisted blob doesn't carry denials forward", () => {
+    const endpoints = getPoolEndpoints(base.id);
+    const targetUrl = endpoints[0];
+
+    observabilityHandle.register(base.id, {
+      endpoints,
+      probeEndpoint: vi.fn(async () => undefined),
+    });
+    recordCorsBlocked(base.id, targetUrl, new TypeError("Failed to fetch"));
+    flushDehydrateForTests();
+
+    // Tamper poolHash on the persisted blob.
+    const raw = window.localStorage.getItem(PERSIST_KEY);
+    expect(raw).not.toBeNull();
+    const blob = JSON.parse(raw!);
+    blob.poolHash = "stale-hash";
+    window.localStorage.setItem(PERSIST_KEY, JSON.stringify(blob));
+
+    __resetForTests({ keepStorage: true });
+    __resetTransportCacheForTests();
+
+    hydrate();
+
+    // The denied set is empty because hydrate dropped the blob entirely.
+    expect(getDeniedEndpointsForChain(base.id).size).toBe(0);
+    expect(window.localStorage.getItem(PERSIST_KEY)).toBeNull();
+  });
+});

--- a/src/utils/rpcPools.ts
+++ b/src/utils/rpcPools.ts
@@ -6,15 +6,6 @@ import {
   ContractFunctionExecutionError,
 } from "viem";
 import {
-  arbitrum,
-  base,
-  baseSepolia,
-  gnosis,
-  mainnet,
-  optimism,
-  polygon,
-} from "viem/chains";
-import {
   recordRequest,
   recordResponse,
   recordCorsBlocked,
@@ -23,172 +14,15 @@ import {
   scheduleAutoRecovery,
   forceProbeChain,
   observabilityHandle,
+  getDeniedEndpointsForChain,
 } from "./rpcObservability";
+import { RPC_POOLS, getPoolEndpoints } from "./poolEndpoints";
 
-/**
- * Per-chain RPC endpoint defaults, ordered most-trusted-first.
- *
- * Curated from chainlist (DefiLlama/chainlist's `extraRpcs.js`) with these filters:
- *   - https only (no wss for now — websocket transport is deferred)
- *   - no embedded API keys (`/<32-hex-chars>` patterns, `?api_key=`, etc.)
- *   - no `tracking: "yes"` providers (Tenderly, Tatum, Lava, Numa, BloxRoute) —
- *     they harvest operator data
- *   - no Alchemy/Infura `/v2/demo` URLs (rate-limit immediately)
- *   - drop URLs we've observed failing browser CORS preflight from
- *     `qips.qidao.localhost` (e.g., 1rpc.io/op and 1rpc.io/arb)
- *
- * The cold-start window matters: viem's fallback rank fires once on transport
- * creation, then sleeps `rank.interval` (30s) before re-probing. Until at
- * least one full probe cycle completes (~1-2s) the active transport is the
- * first entry in this list. Until ~5 minutes pass to fill the sampleCount
- * window the rank's stability score is binary, so input order continues to
- * matter. Order each chain by the most reliable / lowest-latency endpoint
- * first — typically the chain's official endpoint, then well-known multi-
- * chain providers (drpc, publicnode, blastapi, 1rpc).
- *
- * Polygon defaults explicitly EXCLUDE polygon-rpc.com per the
- * polygon-psm-rpc-401-2026-04-22 learning.
- *
- * To refresh from chainlist: `curl -s
- * https://raw.githubusercontent.com/DefiLlama/chainlist/main/constants/extraRpcs.js`
- * and apply the filters above.
- */
-export const RPC_POOLS: Record<number, readonly string[]> = {
-  [base.id]: [
-    "https://mainnet.base.org",
-    "https://base-rpc.publicnode.com",
-    "https://base.drpc.org",
-    "https://base-mainnet.public.blastapi.io",
-    "https://1rpc.io/base",
-    "https://base-public.nodies.app",
-    "https://base.meowrpc.com",
-  ],
-  [baseSepolia.id]: [
-    "https://sepolia.base.org",
-    "https://base-sepolia-rpc.publicnode.com",
-    "https://base-sepolia.drpc.org",
-  ],
-  [mainnet.id]: [
-    "https://ethereum-rpc.publicnode.com",
-    "https://eth.drpc.org",
-    "https://eth-mainnet.public.blastapi.io",
-    "https://1rpc.io/eth",
-    "https://ethereum.public.blockpi.network/v1/rpc/public",
-    "https://eth.meowrpc.com",
-    "https://ethereum-public.nodies.app",
-  ],
-  [polygon.id]: [
-    "https://polygon.drpc.org",
-    "https://polygon-bor-rpc.publicnode.com",
-    "https://1rpc.io/matic",
-    "https://polygon-public.nodies.app",
-  ],
-  [optimism.id]: [
-    "https://mainnet.optimism.io",
-    "https://optimism-rpc.publicnode.com",
-    "https://optimism.drpc.org",
-    "https://optimism.public.blockpi.network/v1/rpc/public",
-    "https://optimism-public.nodies.app",
-  ],
-  [arbitrum.id]: [
-    "https://arb1.arbitrum.io/rpc",
-    "https://arbitrum-one-rpc.publicnode.com",
-    "https://arbitrum.drpc.org",
-    "https://arbitrum-one.public.blastapi.io",
-    "https://arbitrum.public.blockpi.network/v1/rpc/public",
-    "https://arbitrum-one-public.nodies.app",
-    "https://arbitrum.meowrpc.com",
-  ],
-  [gnosis.id]: [
-    "https://rpc.gnosischain.com",
-    "https://gnosis-rpc.publicnode.com",
-    "https://gnosis.drpc.org",
-    "https://1rpc.io/gnosis",
-    "https://gnosis-public.nodies.app",
-  ],
-};
-
-const ENV_KEY_BY_CHAIN_ID: Record<number, { single: string; list: string }> = {
-  [base.id]: { single: "VITE_BASE_RPC_URL", list: "VITE_BASE_RPC_URLS" },
-  [baseSepolia.id]: {
-    single: "VITE_BASE_SEPOLIA_RPC_URL",
-    list: "VITE_BASE_SEPOLIA_RPC_URLS",
-  },
-  [mainnet.id]: { single: "VITE_MAINNET_RPC_URL", list: "VITE_MAINNET_RPC_URLS" },
-  [polygon.id]: { single: "VITE_POLYGON_RPC_URL", list: "VITE_POLYGON_RPC_URLS" },
-  [optimism.id]: {
-    single: "VITE_OPTIMISM_RPC_URL",
-    list: "VITE_OPTIMISM_RPC_URLS",
-  },
-  [arbitrum.id]: {
-    single: "VITE_ARBITRUM_RPC_URL",
-    list: "VITE_ARBITRUM_RPC_URLS",
-  },
-  [gnosis.id]: { single: "VITE_GNOSIS_RPC_URL", list: "VITE_GNOSIS_RPC_URLS" },
-};
-
-function readEnv(key: string): string | undefined {
-  // Mirrors src/config/env.ts:getEnvVar exactly. The optional-chaining variant
-  // I tried first does not consistently surface VITE_* env vars in Vite's
-  // dev pipeline; the explicit typeof guard does.
-  let value: string | undefined;
-  try {
-    if (typeof import.meta !== "undefined" && (import.meta as unknown as { env?: Record<string, string> }).env) {
-      value = (import.meta as unknown as { env: Record<string, string> }).env[key];
-    }
-  } catch {
-    // import.meta is unavailable in some SSR / test contexts.
-  }
-  if (!value && typeof process !== "undefined" && process.env?.[key]) {
-    value = process.env[key];
-  }
-  if (typeof value === "string" && value.length > 0) return value;
-  return undefined;
-}
-
-function readBoolEnv(key: string): boolean {
-  return readEnv(key) === "true";
-}
-
-/**
- * Resolve the endpoint list for a chain.
- *
- * Precedence (top wins):
- *   1. VITE_<CHAIN>_RPC_URLS (comma-split list).
- *   2. VITE_<CHAIN>_RPC_URL (single override; treated as a strict one-element
- *      pool, NOT appended to defaults).
- *   3. RPC_POOLS[chainId] defaults.
- *
- * Local-mode short-circuit: when VITE_LOCAL_MODE=true and the singular
- * VITE_BASE_RPC_URL points at localhost, return only that one URL for base.id
- * regardless of the pool. Preserves the Anvil fork pattern.
- */
-export function getPoolEndpoints(chainId: number): string[] {
-  const envKeys = ENV_KEY_BY_CHAIN_ID[chainId];
-  const localMode = readBoolEnv("VITE_LOCAL_MODE");
-  const singleBaseRpc = readEnv("VITE_BASE_RPC_URL");
-  if (
-    chainId === base.id &&
-    localMode &&
-    singleBaseRpc &&
-    (singleBaseRpc.includes("localhost") || singleBaseRpc.includes("127.0.0.1"))
-  ) {
-    return [singleBaseRpc];
-  }
-  if (envKeys) {
-    const list = readEnv(envKeys.list);
-    if (list) {
-      return list
-        .split(",")
-        .map((url) => url.trim())
-        .filter(Boolean);
-    }
-    const single = readEnv(envKeys.single);
-    if (single) return [single];
-  }
-  const defaults = RPC_POOLS[chainId];
-  return defaults ? [...defaults] : [];
-}
+// Re-export so existing consumers (and tests) can import these from rpcPools
+// without churn while the modules settle. `RPC_POOLS` and `getPoolEndpoints`
+// are owned by `poolEndpoints.ts` (extracted to break the circular import
+// rpcPools ↔ rpcObservability when the latter computes a pool-hash).
+export { RPC_POOLS, getPoolEndpoints };
 
 /**
  * Memoized module-scope cache so every consumer of buildChainTransport for
@@ -266,9 +100,42 @@ export function buildChainTransport(
         `No RPC pool configured for chain ${chainId}. Add an entry to RPC_POOLS in src/utils/rpcPools.ts or set VITE_<CHAIN>_RPC_URL[S].`,
       );
     }
-    const childTransports = endpoints.map((url) =>
+
+    // Composition-time filter: drop URLs that hydrate() seeded as terminal
+    // (cors-blocked / auth-rejected). This is what gives warm reloads their
+    // payoff — endpoints the previous session learned were bad never get
+    // contacted on the next page load until the F10 scheduler tries them.
+    //
+    // Edge case: every endpoint is denied. Fall back to the full pool rather
+    // than constructing a zero-endpoint fallback (which would throw inside
+    // viem). The pool-exhausted banner will surface naturally on actual
+    // request failure, and forceProbeChain (Retry button) can recover.
+    // This is the documented R2 exception in the plan.
+    const denied = getDeniedEndpointsForChain(chainId);
+    const allowedEndpoints = endpoints.filter((url) => !denied.has(url));
+    const activeEndpoints =
+      allowedEndpoints.length > 0 ? allowedEndpoints : endpoints;
+    if (allowedEndpoints.length === 0 && denied.size > 0) {
+      console.warn(
+        `[rpcPools] All endpoints for chain ${chainId} denied at compose time — using full pool with banner state.`,
+      );
+    }
+
+    // observabilityHandle.register below registers the FULL set (including
+    // denied endpoints) so the banner state and F10 scheduler still see the
+    // complete picture. The filter only affects which transports viem's
+    // fallback walks at request time.
+    const childTransports = activeEndpoints.map((url) =>
       http(url, {
-        retryCount: 3,
+        // retryCount: 1 (down from 3) per plan 2026-05-18-001 to cut the
+        // worst-case per-endpoint amplifier from (1 + 3) to (1 + 1) attempts.
+        // Construction-time wins over the runtime-zeroed value fallback
+        // passes — verified at node_modules/viem/_esm/clients/transports/
+        // http.js:15 (`const retryCount = config.retryCount ?? retryCount_`).
+        // viem's Retry-After handling still fires on the single retry per
+        // the `shouldRetry` whitelist in node_modules/viem/_esm/utils/
+        // buildRequest.js (covers 408/413/429/500/502/503/504).
+        retryCount: 1,
         retryDelay: 150,
         onFetchRequest: () => {
           recordRequest(chainId, url);
@@ -308,19 +175,26 @@ export function buildChainTransport(
     // we catch it via a thin wrapper transport that intercepts the error and
     // records before re-throwing. The fallback transport then sees a normal
     // rejection and moves on.
+    // Index into `activeEndpoints` (the filtered set used to build
+    // childTransports) — NOT `endpoints` (which would be misaligned when
+    // any URL was filtered out).
     const wrappedTransports = childTransports.map((t, idx) =>
-      wrapWithFetchErrorObserver(t, chainId, endpoints[idx]),
+      wrapWithFetchErrorObserver(t, chainId, activeEndpoints[idx]),
     );
 
+    // Rank disabled per plan 2026-05-18-001 (production-consensus prior art:
+    // Uniswap, Reown AppKit, Aave, Sushiswap, Dyad, gnars all run with
+    // rank: false). Composition is deterministic and ordered most-trusted-
+    // first in `poolEndpoints.ts`. Endpoint health feeds the pool from
+    // `rpcObservability`'s terminal-state set via `getDeniedEndpointsForChain`
+    // (filter applied at compose time — see filter block above this fallback
+    // call once U5 lands; pre-U5 this comment is forward-looking).
+    //
+    // `observabilityHandle.register` below still uses `eth_blockNumber` as
+    // the probe method via `probeEndpoint`; that path is used by
+    // `forceProbeChain` (Retry button) and `scheduleAutoRecovery`, not by
+    // any per-call ranking.
     const fallbackTransport = fallback(wrappedTransports, {
-      rank: {
-        interval: 30_000,
-        sampleCount: 10,
-        timeout: 1500,
-        weights: { latency: 0.3, stability: 0.7 },
-        ping: ({ transport: pingTransport }) =>
-          pingTransport.request({ method: "eth_blockNumber" }),
-      },
       retryCount: 0,
       shouldThrow: shouldThrowFromFallback,
     });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
@@ -20,5 +21,11 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     sourcemap: true
-  }
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+    setupFiles: ['./vitest.setup.ts'],
+  },
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,54 @@
+// Vitest test setup — runs once per worker before any test file.
+//
+// Node 22+ exposes an experimental `localStorage` getter on `globalThis` that
+// returns `undefined` unless the process is started with
+// `--localstorage-file=<path>`. Neither happy-dom nor jsdom set it up either
+// under the current Vitest 2.x environment. This shim installs a plain
+// in-memory `Storage`-compatible polyfill on `window` (and `globalThis`) so
+// the persistence layer's `window.localStorage.setItem/getItem/removeItem`
+// calls behave correctly under test.
+//
+// Tests opt back to the polyfill via `window.localStorage.clear()` in
+// `beforeEach`. Concurrent test files run in separate workers, so the
+// in-memory store does not leak across files.
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+const storage = new MemoryStorage();
+
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: storage,
+});


### PR DESCRIPTION
## Summary

Follows up #79 with a 4-lever tuning of the Base RPC pool. Verified on a Vercel preview against the prod baseline:

| Metric | Prod (cold) | Preview (cold) | Prod (warm) | Preview (warm) |
| --- | --- | --- | --- | --- |
| Mai API `/v3/qcis` | 145ms | 208ms | 32ms | 78ms |
| Snapshot GraphQL fan-out | 42 | 42 (PR #79) | 0 | 0 |
| **Total RPC** | **100** | **15** | **74** | **0** |
| Non-Base RPC probes | 52 | 0 | 50 | 0 |
| `base.llamarpc.com` hits | 15 | 2 | 8 | 0 |
| `base.api.onfinality.io` hits | 12 | 0 | 8 | 0 |

## The four levers

1. **Extract `RPC_POOLS` + `getPoolEndpoints` into `src/utils/poolEndpoints.ts`** so `rpcObservability.ts` can compute a pool-composition hash without creating the `rpcPools → rpcObservability → rpcPools` cycle. Apply the canonical Base order in the move: `publicnode → drpc → blastapi → 1rpc → meowrpc → nodies → mainnet.base.org`. `mainnet.base.org` demoted to last per Base's own docs ("rate-limited, not designed for production workloads"). Exclude `base.llamarpc.com` (CORS preflight stalls ~10s) and `base.api.onfinality.io/public` (429 immediately under multicall) — documented inline with `// Excluded:` comments so future agents refreshing from chainlist don't re-introduce them.
2. **Disable viem's rank scheduler** (`rank: false`). No production wagmi dapp surveyed enables it (Uniswap, Reown AppKit, Aave, Sushiswap, Dyad, gnars all use `rank: false`). The maintainer has explicitly declined a cooldown API (viem#2540, #2886). Composition is now deterministic + ordered most-trusted-first.
3. **Per-`http()` `retryCount: 1`** (down from 3). Verified construction-time precedence in `node_modules/viem/_esm/clients/transports/http.js:15` — `config.retryCount ?? retryCount_`, so `http(url, { retryCount: 1 })` IS honored inside `fallback`. Cuts the per-endpoint amplifier from `(1 + 3) = 4` to `(1 + 1) = 2` attempts before fallback advances. Retry-After handling still fires on the single retry.
4. **Persist terminal endpoint health to localStorage** under versioned key `qips:rpc-health:v1`. Asymmetric TTL (24h healthy / 1h terminal, matching `AUTO_RECOVERY_DELAYS_MS[0]`). Pool-composition hash invalidates the blob on any `RPC_POOLS` edit. Hydrate runs BEFORE `attachDebugGlobal` and BEFORE the first `buildChainTransport` call so the composition-time filter inside `buildChainTransport` sees the seeded denied set. F10 auto-recovery timers are restored with the elapsed-time clamp on `demotedAt`.

## What's in this PR

- `src/utils/poolEndpoints.ts` — NEW. Extracted `RPC_POOLS`, `getPoolEndpoints`, env-merge, `readEnv`.
- `src/utils/rpcPools.ts` — rank disabled, per-http `retryCount: 1`, composition-time filter using `getDeniedEndpointsForChain(chainId)`. Empty-after-filter falls back to the full pool with a `console.warn` (R2 exception — degraded connectivity beats zero connectivity).
- `src/utils/rpcObservability.ts` — new persistence layer (`dehydrate`, `hydrate`, `getDeniedEndpointsForChain`, `getPoolHash` with inline `cyrb53`), `_setStateFromHydration`, `_restartF10TimerFromDemotedAt`. Also fixed a pre-existing dead-branch in `setState` (`else if (h.state === "healthy")` could never match after the assignment; corrected to `next === "healthy"`).
- `src/providers/Web3Provider.tsx` — module-init reorder: `hydrate() → attachDebugGlobal() → const transports = { ... }`. Statement order IS execution order.
- `src/utils/rpcObservability.test.ts` + `src/utils/rpcPools.test.ts` — NEW. 21 Vitest tests covering TTL gating, pool-hash invalidation, `demotedAt` preservation, F10 timer restoration with elapsed clamp, throttling, error resilience, composition-time filter, empty-after-filter fallback, and the banner false-positive guard.
- `vite.config.ts` + `vitest.setup.ts` — NEW Vitest setup. Includes a `MemoryStorage` polyfill because Vitest 2.x + happy-dom + Node 22 doesn't expose `window.localStorage` (Node 22 experimental-API artifact).
- `package.json` — added `vitest`, `happy-dom` devDeps; `test`/`test:watch` scripts use `node node_modules/vitest/vitest.mjs run` (NOT `bunx vitest` — Bun's runtime shadows `window.localStorage`).

Includes a follow-up fix that prevents the RpcStatusBanner from flashing "RPC unavailable on Base" for ~100ms on cold load when localStorage contained a hydrated `cors-blocked` entry. Root cause: `deriveExhaustedFromSnapshot` iterated only the URLs present in the snapshot, and with a single seeded terminal entry that read as "all known endpoints are dead". Fix: `observabilityHandle.register` now pre-seeds an `unknown` entry for every URL in the registered pool (idempotent — already-hydrated terminal entries are unchanged), so the snapshot reflects the full pool the moment `buildChainTransport` finishes.

## Test plan

- [ ] CI green (typecheck + 21 unit tests + build)
- [ ] GitHub Pages deploy succeeds and `gov.mai.finance/all-proposals` renders
- [ ] Cold load against prod (no localStorage carry-over): Base RPC count drops to ~15 from 100, no non-Base probes appear unless wallet/UI explicitly switches chains
- [ ] Warm reload: 0 RPC requests, page from localStorage cache
- [ ] No "RPC unavailable on Base" banner flash on reload with persisted health
- [ ] DevTools Application panel shows `qips:rpc-health:v1` populated after first cold load