### PR TITLE
fix(snapshot): route proposal block fetch through wagmi mainnet client

### DIFF
--- a/src/components/SnapshotSubmitter.tsx
+++ b/src/components/SnapshotSubmitter.tsx
@@ -2,14 +2,14 @@ import React, { useState } from "react";
 import { useEthersSigner } from "../utils/ethers";
 import { createProposal } from "../utils/snapshotClient";
 import { Proposal } from "@snapshot-labs/snapshot.js/dist/src/sign/types";
-import { ethers } from "ethers";
+import { usePublicClient } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { config } from "../config";
 import { Card, CardContent, CardFooter } from "./ui/card";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import { AlertCircle, CheckCircle2, ExternalLink, Loader2 } from "lucide-react";
-import { base } from "wagmi/chains";
+import { base, mainnet } from "wagmi/chains";
 import { useLinkSnapshotProposal } from "../hooks/useLinkSnapshotProposal";
 import { getLatestQipNumber } from "../utils/snapshotClient";
 import { useQITokenBalance } from "../hooks/useQITokenBalance";
@@ -37,6 +37,10 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
   isEditor = false,
 }) => {
   const signer = useEthersSigner();
+  // Reuse the wagmi-managed mainnet client so we share its single ranked
+  // fallback pool / observability loop instead of spawning a new one per
+  // submission. The submit handler reads the current block from this client.
+  const mainnetClient = usePublicClient({ chainId: mainnet.id });
   const { ensureChain } = useEnsureChain(base.id);
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState<React.ReactNode>(null);
@@ -210,9 +214,13 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
         </div>
       );
       setStatusLevel("info");
-      // Always use Ethereum mainnet blocks for all Snapshot proposals
-      const ethProvider = new ethers.providers.JsonRpcProvider("https://eth.llamarpc.com");
-      const snapshotBlock = await ethProvider.getBlockNumber();
+      // Always use Ethereum mainnet blocks for all Snapshot proposals. Read
+      // through the wagmi-managed mainnet client so the call uses the
+      // configured pool/fallback transport instead of a hardcoded URL.
+      if (!mainnetClient) {
+        throw new Error("Mainnet public client unavailable — wagmi config missing mainnet transport.");
+      }
+      const snapshotBlock = Number(await mainnetClient.getBlockNumber());
 
       // Calculate timestamps right before submission
       const now = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Summary

`SnapshotSubmitter` constructed a one-off `ethers.providers.JsonRpcProvider("https://eth.llamarpc.com")` to fetch the current mainnet block for `proposal.snapshot`. As of today that endpoint returns Cloudflare `error code: 525`, so every "Submit to Snapshot" click fails with `NETWORK_ERROR` after a ~1.6s timeout — even though the app is wired with seven mainnet pool endpoints that are all healthy. The hardcoded URL also bypassed the request/response observability hooks used elsewhere in the app.

This PR routes the read through `usePublicClient({ chainId: mainnet.id })`, which returns the wagmi-managed mainnet client that `Web3Provider` already constructs at app boot. The client uses the same `buildLazyChainTransport(mainnet.id)` factory wired in `src/providers/Web3Provider.tsx:56`, so the submitter gets:

- failover across the seven configured mainnet endpoints (publicnode, drpc, blastapi, 1rpc, blockpi, meowrpc, nodies),
- the standard observability hooks that drive `window.__qipsRpc`,
- no per-submit allocation of a viem `fallback` rank loop. Each `createPublicClient` call binds the `fallback` transport, which starts a perpetual `rankTransports_` self-recurse. Sharing the wagmi singleton keeps it at one loop per chain.

## Diff shape

Single file: `src/components/SnapshotSubmitter.tsx` (+13 / -5).

- Drop `import { ethers } from "ethers"` (default-import was only used at the buggy line).
- Add `import { usePublicClient } from "wagmi"` and extend the existing `import { base } from "wagmi/chains"` to include `mainnet`.
- Hoist `const mainnetClient = usePublicClient({ chainId: mainnet.id })` to the hook layer.
- Inside `handleSubmit`, replace the `JsonRpcProvider`/`getBlockNumber` pair with `Number(await mainnetClient.getBlockNumber())` plus a defensive null guard.

`useEthersSigner` and the rest of the ethers signing path are unchanged — that path is correct: snapshot.js's `client.proposal(signer.provider, ...)` requires an ethers `Web3Provider` wrapped around the wallet, which is what the bridge in `src/utils/ethers.ts` produces.

## Reproduction (before)

Side-by-side against this branch's parent, run from `node_modules/`-resolved cwd, ethers 5.8.0 + viem 2.30:

```
--- PATH A (current: ethers JsonRpcProvider -> eth.llamarpc.com) ---
{ "ok": false, "error": "could not detect network (NETWORK_ERROR)", "ms": 1656 }

--- PATH B (this fix's underlying transport) ---
{ "ok": true, "block": 25138627, "ms": 153 }
```

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run build` — clean (only pre-existing chunk-size warnings).
- [x] Bundle grep: no `eth.llamarpc.com` reference remains in `dist/assets/*.js`.
- [x] Repo grep: no `new (ethers\.providers|providers)\.JsonRpcProvider` constructions remain anywhere under `src/` (the wallet bridge in `src/utils/ethers.ts` builds a `Web3Provider` from the wallet, not a `JsonRpcProvider`).
- [x] Bigint coercion sanity: `Number(getBlockNumber())` for mainnet returns ~2.5e7, ~9e15 of headroom to `Number.MAX_SAFE_INTEGER`.
- [ ] **Manual / pre-merge smoke (requires a wallet):**
  - Connect on a draft QCI page, click "Submit to Snapshot", confirm submission succeeds and the proposal URL is produced.
  - Devtools request-blocking: block 1-2 mainnet pool hosts, retry submit, confirm fallback succeeds.
  - Devtools request-blocking: block all 7 mainnet pool hosts, confirm UI surfaces an error and the loading state clears (no hang).
  - Inspect `window.__qipsRpc.getSnapshot()` before vs after a submit; confirm chain `1` totals increment.
  - Leak test: submit/cancel/retry several times, then watch idle `eth_blockNumber` traffic for ~60-90s. Rate must stay flat (single shared rank loop) and not grow per click.

## Related

Supersedes #81 (which got bloated because the head branch was based on a stale fork main; this PR is rebased onto the current upstream main and contains just the 1-file fix).

Same parallel-read-path family of bug as a previous case (`QCIClient` constructing its own internal `publicClient` and bypassing the configured pool) — the pattern is "every chain-1 read must go through the wagmi-managed mainnet client, not a freshly constructed one."