### PR TITLE
Gate proposal submission on Snapshot's 10k body limit

### DIFF
--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -19,16 +19,11 @@ import { TransactionGroup } from "./TransactionGroup";
 import { type TransactionData, ABIParser } from "../utils/abiParser";
 import { groupTransactionsByMultisig, serializeTransactionsForBody } from "../utils/transactionParser";
 import { formatProposalBody } from "../utils/snapshotPayload";
+import { SNAPSHOT_BODY_WARNING_RATIO } from "@/config/env";
 import { Plus } from "lucide-react";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { getAllChainNames } from '@/config/proposalChains';
-
-// Warning threshold for the advisory counter — render amber at 80% of the
-// limit, destructive (red) above the limit. Matches CommentComposer's
-// canonical pattern. Editor doesn't enforce; the hard gate lives in the
-// submitter. Tooltip on the counter explains the advisory nature.
-const EDITOR_BODY_WARNING_RATIO = 0.8;
 
 interface ProposalEditorProps {
   registryAddress: Address;
@@ -106,34 +101,34 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   const createQCIMutation = useCreateQCI({ registryAddress });
   const updateQCIMutation = useUpdateQCI({ registryAddress });
 
-  // Advisory projection of the Snapshot body the user is composing. Routes
-  // through the same shared serializer (formatProposalBody +
-  // serializeTransactionsForBody) the submitter uses at signature time —
-  // single shared serializer, no parallel size-accounting path. R3 calls
-  // for this counter as an early-feedback signal; the hard gate lives in
-  // SnapshotSubmitter so editing doesn't get blocked on a QCI save (which
-  // writes to IPFS + registry, neither of which has the Snapshot limit).
+  // Advisory Snapshot-body projection — same shared serializer the submitter
+  // uses at signature time. The hard gate lives in SnapshotSubmitter; this
+  // counter is informational so editing isn't blocked on a QCI save.
   //
-  // Pessimistic in two small ways: when implementor / implementation-date
-  // are unset, we emit "None" so the frontmatter row is omitted (matching
-  // the submitter's behavior); and we fall back to today's date for
-  // created if no existing QCI is loaded.
+  // Split into two memos so the per-keystroke `content` change doesn't
+  // re-run the transaction serialization (which round-trips through
+  // ABIParser per tx).
+  const serializedTxsForCounter = useMemo(
+    () => serializeTransactionsForBody(transactions),
+    [transactions]
+  );
+  const existingImplementationDate = existingQCI?.content["implementation-date"];
+  const existingCreated = existingQCI?.content.created;
   const projectedEmbeddedBody = useMemo(() => {
     const frontmatter = {
       chain: combooxSelectedChain,
       author: author || "",
       implementor,
-      "implementation-date": existingQCI?.content["implementation-date"] || "None",
-      created: existingQCI?.content.created || new Date().toISOString().split("T")[0],
+      "implementation-date": existingImplementationDate || "None",
+      created: existingCreated || new Date().toISOString().split("T")[0],
     };
-    const serializedTxs = serializeTransactionsForBody(transactions);
-    return formatProposalBody(content, frontmatter, serializedTxs);
-  }, [content, combooxSelectedChain, author, implementor, existingQCI, transactions]);
+    return formatProposalBody(content, frontmatter, serializedTxsForCounter);
+  }, [content, combooxSelectedChain, author, implementor, existingImplementationDate, existingCreated, serializedTxsForCounter]);
   const editorBodyLength = projectedEmbeddedBody.length;
   const editorBodyLimit = config.snapshotBodyLimitDefault;
   const editorOverLimit = editorBodyLength > editorBodyLimit;
   const editorNearLimit =
-    !editorOverLimit && editorBodyLength >= Math.floor(editorBodyLimit * EDITOR_BODY_WARNING_RATIO);
+    !editorOverLimit && editorBodyLength >= Math.floor(editorBodyLimit * SNAPSHOT_BODY_WARNING_RATIO);
 
   // Initialize transactions from existing QCI content
   useEffect(() => {
@@ -428,26 +423,20 @@ Why this proposal is needed...
 
 Implementation details...`}
           />
-          {/* Advisory Snapshot-body counter — informational only, no gating.
-              Routes through the same shared serializer the submitter uses;
-              tooltip clarifies that the authoritative check happens at
-              Snapshot submission. */}
-          <div className="flex items-center justify-end text-xs">
-            <span
-              className={
-                editorOverLimit
-                  ? "text-destructive"
-                  : editorNearLimit
-                  ? "text-amber-600 dark:text-amber-400"
-                  : "text-muted-foreground"
-              }
-              aria-live="polite"
-              title="Advisory projection — final count is checked at Snapshot submit."
-            >
-              Snapshot body: {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()} chars
-              {editorOverLimit && " — over Snapshot limit"}
-            </span>
-          </div>
+          <span
+            className={`block text-right text-xs ${
+              editorOverLimit
+                ? "text-destructive"
+                : editorNearLimit
+                ? "text-amber-600 dark:text-amber-400"
+                : "text-muted-foreground"
+            }`}
+            aria-live="polite"
+            title="Advisory projection — final count is checked at Snapshot submit."
+          >
+            Snapshot body: {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()} chars
+            {editorOverLimit && " — over Snapshot limit"}
+          </span>
         </div>
 
         {/* Transactions Section */}

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo, useDeferredValue, useImperativeHandle } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo, useImperativeHandle } from 'react';
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAccount, useWalletClient, useSwitchChain } from 'wagmi';
@@ -68,17 +68,114 @@ interface SnapshotBodySectionProps {
   onOverLimitChange: (over: boolean) => void;
 }
 
+// How long the projection waits after the last keystroke before recomputing.
+// 250ms is long enough to skip every intermediate keystroke during a paste
+// burst but short enough that the counter "feels live" once typing pauses.
+const COUNTER_DEBOUNCE_MS = 250;
+
+interface BodyMeterProps {
+  bodyLength: number;
+  bodyLimit: number;
+  frontmatterChars: number;
+  contentCharsValue: number;
+  txCharContribution: number;
+  overLimit: boolean;
+  nearLimit: boolean;
+}
+
 /**
- * Owns the textarea state, the live char counter, the breakdown tooltip, and
- * the optional ReactMarkdown preview — everything that depends on `content`.
+ * Counter + breakdown tooltip subtree. Wrapped in React.memo so it doesn't
+ * re-reconcile on every textarea keystroke — Radix's TooltipProvider tree
+ * contains ~180 internal Primitive.div / SlotClone wrappers per React Scan,
+ * and re-rendering all of them per keystroke was a big chunk of the cost.
+ * Now this subtree only re-renders when its derived props change, which is
+ * only when the debounced projection catches up (every COUNTER_DEBOUNCE_MS
+ * idle period).
+ */
+const BodyMeter = React.memo(function BodyMeter({
+  bodyLength,
+  bodyLimit,
+  frontmatterChars,
+  contentCharsValue,
+  txCharContribution,
+  overLimit,
+  nearLimit,
+}: BodyMeterProps) {
+  return (
+    <div className="flex items-center justify-end gap-1.5">
+      <span
+        className={`text-xs ${
+          overLimit
+            ? "text-destructive"
+            : nearLimit
+            ? "text-amber-600 dark:text-amber-400"
+            : "text-muted-foreground"
+        }`}
+        aria-live="polite"
+        title="Advisory projection — final count is checked at Snapshot submit."
+      >
+        Snapshot body: {bodyLength.toLocaleString()} / {bodyLimit.toLocaleString()} chars
+        {overLimit && " — over Snapshot limit"}
+      </span>
+      <TooltipProvider delayDuration={150}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Snapshot body character breakdown"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Info className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" align="end" className="max-w-xs">
+            <div className="space-y-1.5">
+              <div className="font-semibold">Snapshot body breakdown</div>
+              <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5 text-xs">
+                <span>YAML frontmatter</span>
+                <span className="text-right tabular-nums">{frontmatterChars.toLocaleString()}</span>
+                <span>Proposal content</span>
+                <span className="text-right tabular-nums">{contentCharsValue.toLocaleString()}</span>
+                {txCharContribution > 0 && (
+                  <>
+                    <span>Transactions block</span>
+                    <span className="text-right tabular-nums">{txCharContribution.toLocaleString()}</span>
+                  </>
+                )}
+                <span className="border-t border-primary-foreground/20 pt-0.5 font-medium">Total</span>
+                <span className="border-t border-primary-foreground/20 pt-0.5 text-right font-medium tabular-nums">
+                  {bodyLength.toLocaleString()} / {bodyLimit.toLocaleString()}
+                </span>
+              </div>
+              <div className="pt-1 text-[10px] opacity-80">
+                Frontmatter and transactions are emitted by the Snapshot serializer in addition to your markdown content. Advisory projection — the submitter does the final check.
+              </div>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+});
+
+/**
+ * Owns the textarea state, the live char counter, and the breakdown tooltip.
  * Wrapped in React.memo + ref so per-keystroke updates stay isolated to this
  * subtree and don't drag the parent ProposalEditor's other children
  * (ChainCombobox, Transactions section, TransactionFormatter modal, the
  * Radix slot primitives) through reconciliation.
  *
- * The parent reads content via `ref.current.getContent()` at submit time and
- * pushes content back via `ref.current.setContent()` when an existing QCI's
- * data loads asynchronously.
+ * The projection memos read a setTimeout-debounced copy of content so they
+ * don't run on every keystroke — useDeferredValue alone wasn't enough
+ * because it still committed the deferred render at low priority, and the
+ * Radix Tooltip subtree underneath the counter has enough internal wrappers
+ * that even a fast re-reconcile per keystroke costs noticeable ms in dev.
+ * The BodyMeter subcomponent is React.memo so it skips re-render entirely
+ * unless its derived props change.
+ *
+ * The parent reads content via `ref.current.getContent()` at submit time
+ * and pushes content back via `ref.current.setContent()` when an existing
+ * QCI's data loads asynchronously.
  */
 const SnapshotBodySection = React.memo(
   React.forwardRef<SnapshotBodySectionHandle, SnapshotBodySectionProps>(
@@ -87,7 +184,15 @@ const SnapshotBodySection = React.memo(
       ref
     ) {
       const [content, setContent] = useState(initialContent);
-      const deferredContent = useDeferredValue(content);
+      // Debounced copy of content. The textarea binds to `content` for
+      // snappy input; projection memos read `debouncedContent` so they
+      // only run after typing has paused for COUNTER_DEBOUNCE_MS.
+      const [debouncedContent, setDebouncedContent] = useState(initialContent);
+      useEffect(() => {
+        const t = setTimeout(() => setDebouncedContent(content), COUNTER_DEBOUNCE_MS);
+        return () => clearTimeout(t);
+      }, [content]);
+
       // Opt-in subscribers (e.g., the rich preview block) that want
       // content updates without forcing the parent to re-render per
       // keystroke. We notify them in an effect so React owns the timing.
@@ -97,12 +202,12 @@ const SnapshotBodySection = React.memo(
       }, [content]);
 
       const projectedEmbeddedBody = useMemo(
-        () => formatProposalBody(deferredContent, frontmatter, serializedTxs),
-        [deferredContent, frontmatter, serializedTxs]
+        () => formatProposalBody(debouncedContent, frontmatter, serializedTxs),
+        [debouncedContent, frontmatter, serializedTxs]
       );
       const projectedBodyWithoutTxs = useMemo(
-        () => formatProposalBody(deferredContent, frontmatter, undefined),
-        [deferredContent, frontmatter]
+        () => formatProposalBody(debouncedContent, frontmatter, undefined),
+        [debouncedContent, frontmatter]
       );
       const projectedBodyFrontmatterOnly = useMemo(
         () => formatProposalBody("", frontmatter, undefined),
@@ -139,17 +244,16 @@ const SnapshotBodySection = React.memo(
       );
 
       return (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="content">Proposal Content (Markdown) *</Label>
-            <Textarea
-              id="content"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              required
-              rows={20}
-              className="font-mono text-sm"
-              placeholder={`## Summary
+        <div className="space-y-2">
+          <Label htmlFor="content">Proposal Content (Markdown) *</Label>
+          <Textarea
+            id="content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            required
+            rows={20}
+            className="font-mono text-sm"
+            placeholder={`## Summary
 
 Brief overview of your proposal...
 
@@ -164,62 +268,17 @@ Why this proposal is needed...
 ## Technical Specification
 
 Implementation details...`}
-            />
-            <div className="flex items-center justify-end gap-1.5">
-              <span
-                className={`text-xs ${
-                  overLimit
-                    ? "text-destructive"
-                    : nearLimit
-                    ? "text-amber-600 dark:text-amber-400"
-                    : "text-muted-foreground"
-                }`}
-                aria-live="polite"
-                title="Advisory projection — final count is checked at Snapshot submit."
-              >
-                Snapshot body: {editorBodyLength.toLocaleString()} / {bodyLimit.toLocaleString()} chars
-                {overLimit && " — over Snapshot limit"}
-              </span>
-              <TooltipProvider delayDuration={150}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label="Snapshot body character breakdown"
-                      className="text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      <Info className="h-3.5 w-3.5" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" align="end" className="max-w-xs">
-                    <div className="space-y-1.5">
-                      <div className="font-semibold">Snapshot body breakdown</div>
-                      <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5 text-xs">
-                        <span>YAML frontmatter</span>
-                        <span className="text-right tabular-nums">{frontmatterChars.toLocaleString()}</span>
-                        <span>Proposal content</span>
-                        <span className="text-right tabular-nums">{contentCharsValue.toLocaleString()}</span>
-                        {txCharContribution > 0 && (
-                          <>
-                            <span>Transactions block</span>
-                            <span className="text-right tabular-nums">{txCharContribution.toLocaleString()}</span>
-                          </>
-                        )}
-                        <span className="border-t border-primary-foreground/20 pt-0.5 font-medium">Total</span>
-                        <span className="border-t border-primary-foreground/20 pt-0.5 text-right font-medium tabular-nums">
-                          {editorBodyLength.toLocaleString()} / {bodyLimit.toLocaleString()}
-                        </span>
-                      </div>
-                      <div className="pt-1 text-[10px] opacity-80">
-                        Frontmatter and transactions are emitted by the Snapshot serializer in addition to your markdown content. Advisory projection — the submitter does the final check.
-                      </div>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-          </div>
-        </>
+          />
+          <BodyMeter
+            bodyLength={editorBodyLength}
+            bodyLimit={bodyLimit}
+            frontmatterChars={frontmatterChars}
+            contentCharsValue={contentCharsValue}
+            txCharContribution={txCharContribution}
+            overLimit={overLimit}
+            nearLimit={nearLimit}
+          />
+        </div>
       );
     }
   )
@@ -439,7 +498,7 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
       // A QCI saved over the Snapshot body limit can never be submitted to
       // Snapshot — block save here so we don't write wasted content to IPFS
       // + the registry. Read the URGENT content via the body section's ref
-      // (the child's display counter uses useDeferredValue and can lag); a
+      // (the child's display counter is debounced and lags up to ~250ms); a
       // fast typist who clicks Save during that lag must still get gated.
       const content = bodyRef.current?.getContent() ?? "";
       const freshBody = formatProposalBody(content, editorFrontmatter, serializedTxsForCounter);

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -14,13 +14,14 @@ import { Label } from '@/components/ui/label';
 import { ChainCombobox } from "./ChainCombobox";
 import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { TransactionFormatter } from "./TransactionFormatter";
 import { TransactionGroup } from "./TransactionGroup";
 import { type TransactionData, ABIParser } from "../utils/abiParser";
 import { groupTransactionsByMultisig, serializeTransactionsForBody } from "../utils/transactionParser";
 import { formatProposalBody } from "../utils/snapshotPayload";
 import { SNAPSHOT_BODY_WARNING_RATIO } from "@/config/env";
-import { Plus } from "lucide-react";
+import { Info, Plus } from "lucide-react";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { getAllChainNames } from '@/config/proposalChains';
@@ -137,7 +138,17 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
     () => formatProposalBody(content, editorFrontmatter, undefined),
     [content, editorFrontmatter]
   );
+  // Empty-content baseline so we can attribute the YAML-frontmatter overhead
+  // separately in the breakdown tooltip. formatProposalBody is additive
+  // (frontmatter + "\n\n" + content + tx-block), so the three deltas sum to
+  // the total body length.
+  const projectedBodyFrontmatterOnly = useMemo(
+    () => formatProposalBody("", editorFrontmatter, undefined),
+    [editorFrontmatter]
+  );
   const editorBodyLength = projectedEmbeddedBody.length;
+  const frontmatterChars = projectedBodyFrontmatterOnly.length;
+  const contentChars = projectedBodyWithoutTxs.length - projectedBodyFrontmatterOnly.length;
   const txCharContribution = projectedEmbeddedBody.length - projectedBodyWithoutTxs.length;
   const editorBodyLimit = config.snapshotBodyLimitDefault;
   const editorOverLimit = editorBodyLength > editorBodyLimit;
@@ -448,20 +459,59 @@ Why this proposal is needed...
 
 Implementation details...`}
           />
-          <span
-            className={`block text-right text-xs ${
-              editorOverLimit
-                ? "text-destructive"
-                : editorNearLimit
-                ? "text-amber-600 dark:text-amber-400"
-                : "text-muted-foreground"
-            }`}
-            aria-live="polite"
-            title="Advisory projection — final count is checked at Snapshot submit."
-          >
-            Snapshot body: {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()} chars
-            {editorOverLimit && " — over Snapshot limit"}
-          </span>
+          <div className="flex items-center justify-end gap-1.5">
+            <span
+              className={`text-xs ${
+                editorOverLimit
+                  ? "text-destructive"
+                  : editorNearLimit
+                  ? "text-amber-600 dark:text-amber-400"
+                  : "text-muted-foreground"
+              }`}
+              aria-live="polite"
+              title="Advisory projection — final count is checked at Snapshot submit."
+            >
+              Snapshot body: {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()} chars
+              {editorOverLimit && " — over Snapshot limit"}
+            </span>
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Snapshot body character breakdown"
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" align="end" className="max-w-xs">
+                  <div className="space-y-1.5">
+                    <div className="font-semibold">Snapshot body breakdown</div>
+                    <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5 text-xs">
+                      <span>YAML frontmatter</span>
+                      <span className="text-right tabular-nums">{frontmatterChars.toLocaleString()}</span>
+                      <span>Proposal content</span>
+                      <span className="text-right tabular-nums">{contentChars.toLocaleString()}</span>
+                      {txCharContribution > 0 && (
+                        <>
+                          <span>Transactions block</span>
+                          <span className="text-right tabular-nums">{txCharContribution.toLocaleString()}</span>
+                        </>
+                      )}
+                      <span className="border-t border-primary-foreground/20 pt-0.5 font-medium">Total</span>
+                      <span className="border-t border-primary-foreground/20 pt-0.5 text-right font-medium tabular-nums">
+                        {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()}
+                      </span>
+                    </div>
+                    <div className="pt-1 text-[10px] opacity-80">
+                      Frontmatter and transactions are emitted by the Snapshot serializer in addition to your markdown content. Advisory projection — the submitter does the final check.
+                    </div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
         </div>
 
         {/* Transactions Section */}

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -41,15 +41,17 @@ interface ProposalEditorProps {
 
 /**
  * Imperative handle exposed by SnapshotBodySection so the parent can read
- * the latest content at submit time, reset it after a successful save, and
- * (opt-in) subscribe to content changes while the rich preview block is
- * mounted — without re-rendering the parent on every keystroke.
+ * the latest content at submit time and reset it after a successful save —
+ * without re-rendering the parent on every keystroke. The handle object
+ * itself is stable across renders (created once); getContent reads from a
+ * ref that's synced after every render.
+ *
+ * Preview is now snapshot-on-click (see handlePreview in the parent), so
+ * no subscription API is exposed.
  */
 export interface SnapshotBodySectionHandle {
   getContent: () => string;
   setContent: (next: string) => void;
-  /** Subscribe to content changes. Returns an unsubscribe function. */
-  subscribe: (cb: (content: string) => void) => () => void;
 }
 
 interface SnapshotBodyFrontmatter {
@@ -184,6 +186,13 @@ const SnapshotBodySection = React.memo(
       ref
     ) {
       const [content, setContent] = useState(initialContent);
+      // Mirror of content held in a ref so the imperative handle can read
+      // the latest value without depending on `content` in its deps array.
+      // Without this, every keystroke would re-create the handle object,
+      // adding per-render allocation churn for no reader benefit.
+      const contentRef = useRef(content);
+      contentRef.current = content;
+
       // Debounced copy of content. The textarea binds to `content` for
       // snappy input; projection memos read `debouncedContent` so they
       // only run after typing has paused for COUNTER_DEBOUNCE_MS.
@@ -191,14 +200,6 @@ const SnapshotBodySection = React.memo(
       useEffect(() => {
         const t = setTimeout(() => setDebouncedContent(content), COUNTER_DEBOUNCE_MS);
         return () => clearTimeout(t);
-      }, [content]);
-
-      // Opt-in subscribers (e.g., the rich preview block) that want
-      // content updates without forcing the parent to re-render per
-      // keystroke. We notify them in an effect so React owns the timing.
-      const subscribersRef = useRef<Set<(content: string) => void>>(new Set());
-      useEffect(() => {
-        for (const cb of subscribersRef.current) cb(content);
       }, [content]);
 
       const projectedEmbeddedBody = useMemo(
@@ -231,16 +232,10 @@ const SnapshotBodySection = React.memo(
       useImperativeHandle(
         ref,
         () => ({
-          getContent: () => content,
+          getContent: () => contentRef.current,
           setContent,
-          subscribe: (cb) => {
-            subscribersRef.current.add(cb);
-            return () => {
-              subscribersRef.current.delete(cb);
-            };
-          },
         }),
-        [content]
+        []
       );
 
       return (
@@ -341,17 +336,6 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   const [success, setSuccess] = useState<string | null>(null);
   const [preview, setPreview] = useState(false);
 
-  // Subscribe the preview block to body content changes ONLY while preview
-  // is open. This keeps typing fast in the default case (preview off, no
-  // parent re-renders per keystroke). When preview is on, the parent does
-  // re-render per keystroke so ReactMarkdown stays current — that's the
-  // acknowledged tradeoff and only happens when the user has explicitly
-  // opted into the slower preview view.
-  useEffect(() => {
-    if (!preview) return;
-    setPreviewContent(bodyRef.current?.getContent() ?? "");
-    return bodyRef.current?.subscribe(setPreviewContent);
-  }, [preview]);
   const [showTransactionModal, setShowTransactionModal] = useState(false);
   const [transactions, setTransactions] = useState<TransactionData[]>([]);
   const [editingTransactionIndex, setEditingTransactionIndex] = useState<number | null>(null);
@@ -398,10 +382,12 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
     setIsContentOverLimit(over);
   }, []);
 
-  // Live content mirror for the rich preview block ONLY. We subscribe to the
-  // body section's content updates while the preview is open, and unsubscribe
-  // when it closes. When preview is off, no subscription is active and
-  // typing in the textarea never re-renders this parent.
+  // Snapshot of the body content captured when Preview is toggled on. The
+  // preview is intentionally not live: typing with preview open would force
+  // ReactMarkdown to re-parse on every keystroke and force a parent
+  // re-render through the subscription, which dragged the whole editor
+  // through reconciliation per Codex's diagnosis. The user toggles Preview
+  // off, edits, then toggles Preview on again to see fresh output.
   const [previewContent, setPreviewContent] = useState("");
 
   const editorBodyLimit = config.snapshotBodyLimitDefault;
@@ -417,6 +403,30 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
     const withoutTxs = formatProposalBody("", editorFrontmatter, undefined);
     return withTxs.length - withoutTxs.length;
   }, [editorFrontmatter, serializedTxsForCounter]);
+
+  // Memoized JSON string for the transactions-preview <pre> block. Previously
+  // this ran groupTransactionsByMultisig → ABIParser.formatTransaction →
+  // JSON.parse → JSON.stringify inside the render function, allocating heavily
+  // on every parent re-render. Codex flagged this as a second-order GC
+  // pressure source. Now it computes once when transactions change.
+  const transactionsPreviewJSON = useMemo(() => {
+    if (transactions.length === 0) return null;
+    return JSON.stringify(
+      groupTransactionsByMultisig(transactions).map(group => ({
+        multisig: group.multisig,
+        transactions: group.transactions.map((tx) => {
+          const formatted = ABIParser.formatTransaction(tx);
+          try {
+            return JSON.parse(formatted);
+          } catch {
+            return formatted;
+          }
+        }),
+      })),
+      null,
+      2
+    );
+  }, [transactions]);
 
   // Initialize transactions from existing QCI content
   useEffect(() => {
@@ -603,6 +613,14 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   );
 
   const handlePreview = () => {
+    if (!preview) {
+      // Toggling preview ON — snapshot the current body content right now.
+      // The preview block reads `previewContent`, not a live subscription,
+      // so editing doesn't cascade into ReactMarkdown re-parses while
+      // preview is open. To see fresh content, the user toggles back to
+      // Edit, makes changes, and re-opens Preview.
+      setPreviewContent(bodyRef.current?.getContent() ?? "");
+    }
     setPreview(!preview);
   };
 
@@ -786,24 +804,7 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
               <div className="mt-8 pt-6 border-t border-border">
                 <h2 className="text-xl font-bold mb-4">Transactions</h2>
                 <pre className="bg-muted/50 p-4 rounded-lg overflow-x-auto">
-                  <code className="text-sm font-mono">
-                    {JSON.stringify(
-                      // Group transactions by multisig for preview
-                      groupTransactionsByMultisig(transactions).map(group => ({
-                        multisig: group.multisig,
-                        transactions: group.transactions.map((tx) => {
-                          const formatted = ABIParser.formatTransaction(tx);
-                          try {
-                            return JSON.parse(formatted);
-                          } catch {
-                            return formatted;
-                          }
-                        }),
-                      })),
-                      null,
-                      2
-                    )}
-                  </code>
+                  <code className="text-sm font-mono">{transactionsPreviewJSON}</code>
                 </pre>
               </div>
             )}

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -207,6 +207,17 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
         return;
       }
 
+      // A QCI saved over the Snapshot body limit can never be submitted to
+      // Snapshot — block save here so we don't write wasted content to IPFS
+      // + the registry. The submitter has the same gate, but catching it at
+      // editor save is the kinder UX.
+      if (editorOverLimit) {
+        setError(
+          `Proposal body is ${editorBodyLength.toLocaleString()} chars — over Snapshot's ${editorBodyLimit.toLocaleString()}-char limit. Shorten before saving.`
+        );
+        return;
+      }
+
       setError(null);
       setSuccess(null);
       setSaving(true);
@@ -297,7 +308,7 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
         setSaving(false);
       }
     },
-    [address, title, combooxSelectedChain, content, implementor, existingQCI, transactions, author, createQCIMutation, updateQCIMutation, navigate]
+    [address, title, combooxSelectedChain, content, implementor, existingQCI, transactions, author, createQCIMutation, updateQCIMutation, navigate, editorOverLimit, editorBodyLength, editorBodyLimit]
   );
 
   const handlePreview = () => {
@@ -473,8 +484,14 @@ Implementation details...`}
         </div>
 
         <div className="flex space-x-4">
-          <Button type="submit" disabled={saving} variant="gradient-primary" size="lg">
-            {saving ? "Saving..." : existingQCI ? "Update QCI" : "Create QCI"}
+          <Button type="submit" disabled={saving || editorOverLimit} variant="gradient-primary" size="lg">
+            {saving
+              ? "Saving..."
+              : editorOverLimit
+              ? `Body over Snapshot limit (${editorBodyLength.toLocaleString()} / ${editorBodyLimit.toLocaleString()})`
+              : existingQCI
+              ? "Update QCI"
+              : "Create QCI"}
           </Button>
 
           <Button type="button" onClick={handlePreview} variant="outline" size="lg">

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo, useDeferredValue } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo, useDeferredValue, useImperativeHandle } from 'react';
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAccount, useWalletClient, useSwitchChain } from 'wagmi';
@@ -38,6 +38,193 @@ interface ProposalEditorProps {
   initialContent?: string;
   initialImplementor?: string;
 }
+
+/**
+ * Imperative handle exposed by SnapshotBodySection so the parent can read
+ * the latest content at submit time, reset it after a successful save, and
+ * (opt-in) subscribe to content changes while the rich preview block is
+ * mounted — without re-rendering the parent on every keystroke.
+ */
+export interface SnapshotBodySectionHandle {
+  getContent: () => string;
+  setContent: (next: string) => void;
+  /** Subscribe to content changes. Returns an unsubscribe function. */
+  subscribe: (cb: (content: string) => void) => () => void;
+}
+
+interface SnapshotBodyFrontmatter {
+  chain: string;
+  author: string;
+  implementor: string;
+  "implementation-date": string;
+  created: string;
+}
+
+interface SnapshotBodySectionProps {
+  initialContent: string;
+  frontmatter: SnapshotBodyFrontmatter;
+  serializedTxs: string | undefined;
+  bodyLimit: number;
+  onOverLimitChange: (over: boolean) => void;
+}
+
+/**
+ * Owns the textarea state, the live char counter, the breakdown tooltip, and
+ * the optional ReactMarkdown preview — everything that depends on `content`.
+ * Wrapped in React.memo + ref so per-keystroke updates stay isolated to this
+ * subtree and don't drag the parent ProposalEditor's other children
+ * (ChainCombobox, Transactions section, TransactionFormatter modal, the
+ * Radix slot primitives) through reconciliation.
+ *
+ * The parent reads content via `ref.current.getContent()` at submit time and
+ * pushes content back via `ref.current.setContent()` when an existing QCI's
+ * data loads asynchronously.
+ */
+const SnapshotBodySection = React.memo(
+  React.forwardRef<SnapshotBodySectionHandle, SnapshotBodySectionProps>(
+    function SnapshotBodySection(
+      { initialContent, frontmatter, serializedTxs, bodyLimit, onOverLimitChange },
+      ref
+    ) {
+      const [content, setContent] = useState(initialContent);
+      const deferredContent = useDeferredValue(content);
+      // Opt-in subscribers (e.g., the rich preview block) that want
+      // content updates without forcing the parent to re-render per
+      // keystroke. We notify them in an effect so React owns the timing.
+      const subscribersRef = useRef<Set<(content: string) => void>>(new Set());
+      useEffect(() => {
+        for (const cb of subscribersRef.current) cb(content);
+      }, [content]);
+
+      const projectedEmbeddedBody = useMemo(
+        () => formatProposalBody(deferredContent, frontmatter, serializedTxs),
+        [deferredContent, frontmatter, serializedTxs]
+      );
+      const projectedBodyWithoutTxs = useMemo(
+        () => formatProposalBody(deferredContent, frontmatter, undefined),
+        [deferredContent, frontmatter]
+      );
+      const projectedBodyFrontmatterOnly = useMemo(
+        () => formatProposalBody("", frontmatter, undefined),
+        [frontmatter]
+      );
+
+      const editorBodyLength = projectedEmbeddedBody.length;
+      const frontmatterChars = projectedBodyFrontmatterOnly.length;
+      const contentCharsValue = projectedBodyWithoutTxs.length - projectedBodyFrontmatterOnly.length;
+      const txCharContribution = projectedEmbeddedBody.length - projectedBodyWithoutTxs.length;
+      const overLimit = editorBodyLength > bodyLimit;
+      const nearLimit = !overLimit && editorBodyLength >= Math.floor(bodyLimit * SNAPSHOT_BODY_WARNING_RATIO);
+
+      // Notify the parent only when the over-limit flag actually flips, so
+      // the parent's Update/Create button can disable without subscribing
+      // to every keystroke.
+      useEffect(() => {
+        onOverLimitChange(overLimit);
+      }, [overLimit, onOverLimitChange]);
+
+      useImperativeHandle(
+        ref,
+        () => ({
+          getContent: () => content,
+          setContent,
+          subscribe: (cb) => {
+            subscribersRef.current.add(cb);
+            return () => {
+              subscribersRef.current.delete(cb);
+            };
+          },
+        }),
+        [content]
+      );
+
+      return (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="content">Proposal Content (Markdown) *</Label>
+            <Textarea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              required
+              rows={20}
+              className="font-mono text-sm"
+              placeholder={`## Summary
+
+Brief overview of your proposal...
+
+## Abstract
+
+Detailed explanation...
+
+## Rationale
+
+Why this proposal is needed...
+
+## Technical Specification
+
+Implementation details...`}
+            />
+            <div className="flex items-center justify-end gap-1.5">
+              <span
+                className={`text-xs ${
+                  overLimit
+                    ? "text-destructive"
+                    : nearLimit
+                    ? "text-amber-600 dark:text-amber-400"
+                    : "text-muted-foreground"
+                }`}
+                aria-live="polite"
+                title="Advisory projection — final count is checked at Snapshot submit."
+              >
+                Snapshot body: {editorBodyLength.toLocaleString()} / {bodyLimit.toLocaleString()} chars
+                {overLimit && " — over Snapshot limit"}
+              </span>
+              <TooltipProvider delayDuration={150}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="Snapshot body character breakdown"
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      <Info className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="end" className="max-w-xs">
+                    <div className="space-y-1.5">
+                      <div className="font-semibold">Snapshot body breakdown</div>
+                      <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5 text-xs">
+                        <span>YAML frontmatter</span>
+                        <span className="text-right tabular-nums">{frontmatterChars.toLocaleString()}</span>
+                        <span>Proposal content</span>
+                        <span className="text-right tabular-nums">{contentCharsValue.toLocaleString()}</span>
+                        {txCharContribution > 0 && (
+                          <>
+                            <span>Transactions block</span>
+                            <span className="text-right tabular-nums">{txCharContribution.toLocaleString()}</span>
+                          </>
+                        )}
+                        <span className="border-t border-primary-foreground/20 pt-0.5 font-medium">Total</span>
+                        <span className="border-t border-primary-foreground/20 pt-0.5 text-right font-medium tabular-nums">
+                          {editorBodyLength.toLocaleString()} / {bodyLimit.toLocaleString()}
+                        </span>
+                      </div>
+                      <div className="pt-1 text-[10px] opacity-80">
+                        Frontmatter and transactions are emitted by the Snapshot serializer in addition to your markdown content. Advisory projection — the submitter does the final check.
+                      </div>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          </div>
+        </>
+      );
+    }
+  )
+);
+SnapshotBodySection.displayName = "SnapshotBodySection";
 
 export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   registryAddress,
@@ -79,11 +266,13 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   const [combooxSelectedChain, setComboboxSelectedChain] = useState(
     existingQCI?.content.chain || importedData?.chain || initialChain || "Polygon PoS"
   );
-  const [content, setContent] = useState(
-    existingQCI?.content.content
-      ? getContentWithoutTransactions(existingQCI.content.content)
-      : importedData?.content || initialContent || ""
-  );
+  // Initial value passed into SnapshotBodySection on mount. The child owns
+  // the live content state from this point; the parent reads it via
+  // bodyRef.current.getContent() at submit time, and pushes updates back
+  // via bodyRef.current.setContent() when existingQCI loads asynchronously.
+  const initialContentValue = existingQCI?.content.content
+    ? getContentWithoutTransactions(existingQCI.content.content)
+    : importedData?.content || initialContent || "";
   const [implementor, setImplementor] = useState(
     existingQCI?.content.implementor || importedData?.implementor || initialImplementor || "None"
   );
@@ -92,6 +281,18 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [preview, setPreview] = useState(false);
+
+  // Subscribe the preview block to body content changes ONLY while preview
+  // is open. This keeps typing fast in the default case (preview off, no
+  // parent re-renders per keystroke). When preview is on, the parent does
+  // re-render per keystroke so ReactMarkdown stays current — that's the
+  // acknowledged tradeoff and only happens when the user has explicitly
+  // opted into the slower preview view.
+  useEffect(() => {
+    if (!preview) return;
+    setPreviewContent(bodyRef.current?.getContent() ?? "");
+    return bodyRef.current?.subscribe(setPreviewContent);
+  }, [preview]);
   const [showTransactionModal, setShowTransactionModal] = useState(false);
   const [transactions, setTransactions] = useState<TransactionData[]>([]);
   const [editingTransactionIndex, setEditingTransactionIndex] = useState<number | null>(null);
@@ -125,42 +326,38 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
     }),
     [combooxSelectedChain, author, implementor, existingImplementationDate, existingCreated]
   );
-  // Defer the per-keystroke `content` value so the textarea stays responsive
-  // while the formatProposalBody projections (regex strips, string concat,
-  // tx serialization) run at a lower priority. React keeps the input
-  // urgent; the counter "catches up" between keystrokes. The submit-time
-  // gate in handleSubmit recomputes against the urgent `content` so a fast
-  // typist can't slip an over-limit save through during the deferred lag.
-  const deferredContent = useDeferredValue(content);
-  const projectedEmbeddedBody = useMemo(
-    () => formatProposalBody(deferredContent, editorFrontmatter, serializedTxsForCounter),
-    [deferredContent, editorFrontmatter, serializedTxsForCounter]
-  );
-  // Body without the transactions section — used to compute the tx-only
-  // char contribution so the editor can show "Transactions: +N chars" next
-  // to the Transactions header. Avoids the user wondering where the bulk
-  // of the body length is coming from when txs are collapsed into "N
-  // transactions" in the UI.
-  const projectedBodyWithoutTxs = useMemo(
-    () => formatProposalBody(deferredContent, editorFrontmatter, undefined),
-    [deferredContent, editorFrontmatter]
-  );
-  // Empty-content baseline so we can attribute the YAML-frontmatter overhead
-  // separately in the breakdown tooltip. formatProposalBody is additive
-  // (frontmatter + "\n\n" + content + tx-block), so the three deltas sum to
-  // the total body length.
-  const projectedBodyFrontmatterOnly = useMemo(
-    () => formatProposalBody("", editorFrontmatter, undefined),
-    [editorFrontmatter]
-  );
-  const editorBodyLength = projectedEmbeddedBody.length;
-  const frontmatterChars = projectedBodyFrontmatterOnly.length;
-  const contentChars = projectedBodyWithoutTxs.length - projectedBodyFrontmatterOnly.length;
-  const txCharContribution = projectedEmbeddedBody.length - projectedBodyWithoutTxs.length;
+  // Content state lives inside <SnapshotBodySection>; the parent reads it
+  // imperatively via this ref at submit time. This prevents the parent
+  // (and its other children — ChainCombobox, Transactions section,
+  // TransactionFormatter modal, Radix slot primitives) from re-rendering
+  // on every keystroke. React Scan profile confirmed those non-content
+  // children were costing 1-3ms each per keystroke; isolating the
+  // textarea cuts the per-frame work to just the body section's subtree.
+  const bodyRef = useRef<SnapshotBodySectionHandle>(null);
+  const [isContentOverLimit, setIsContentOverLimit] = useState(false);
+  const handleOverLimitChange = useCallback((over: boolean) => {
+    setIsContentOverLimit(over);
+  }, []);
+
+  // Live content mirror for the rich preview block ONLY. We subscribe to the
+  // body section's content updates while the preview is open, and unsubscribe
+  // when it closes. When preview is off, no subscription is active and
+  // typing in the textarea never re-renders this parent.
+  const [previewContent, setPreviewContent] = useState("");
+
   const editorBodyLimit = config.snapshotBodyLimitDefault;
-  const editorOverLimit = editorBodyLength > editorBodyLimit;
-  const editorNearLimit =
-    !editorOverLimit && editorBodyLength >= Math.floor(editorBodyLimit * SNAPSHOT_BODY_WARNING_RATIO);
+
+  // Tx-contribution badge for the Transactions section header. Computed
+  // without `content` because the JSON tx block in formatProposalBody is
+  // content-independent: the difference between with-txs and without-txs
+  // bodies on an empty content cancels out the YAML and leaves the pure
+  // tx-block contribution. Updates only when txs or frontmatter change,
+  // not per keystroke.
+  const txCharContribution = useMemo(() => {
+    const withTxs = formatProposalBody("", editorFrontmatter, serializedTxsForCounter);
+    const withoutTxs = formatProposalBody("", editorFrontmatter, undefined);
+    return withTxs.length - withoutTxs.length;
+  }, [editorFrontmatter, serializedTxsForCounter]);
 
   // Initialize transactions from existing QCI content
   useEffect(() => {
@@ -241,11 +438,10 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
 
       // A QCI saved over the Snapshot body limit can never be submitted to
       // Snapshot — block save here so we don't write wasted content to IPFS
-      // + the registry. Recompute against the URGENT `content` value (not
-      // the deferred projection driving the visual counter) so a fast
-      // typist can't slip an over-limit save through during the deferred
-      // catch-up window. The submitter has its own authoritative gate, but
-      // catching it here is the kinder UX.
+      // + the registry. Read the URGENT content via the body section's ref
+      // (the child's display counter uses useDeferredValue and can lag); a
+      // fast typist who clicks Save during that lag must still get gated.
+      const content = bodyRef.current?.getContent() ?? "";
       const freshBody = formatProposalBody(content, editorFrontmatter, serializedTxsForCounter);
       if (freshBody.length > editorBodyLimit) {
         setError(
@@ -329,7 +525,7 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
         // Reset form only for new QCIs that don't redirect
         if (!existingQCI && qciNumber === 0n) {
           setTitle("");
-          setContent("");
+          bodyRef.current?.setContent("");
           setImplementor("None");
         }
       } catch (err: any) {
@@ -344,7 +540,7 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
         setSaving(false);
       }
     },
-    [address, title, combooxSelectedChain, content, implementor, existingQCI, transactions, author, createQCIMutation, updateQCIMutation, navigate, editorFrontmatter, serializedTxsForCounter, editorBodyLimit]
+    [address, title, combooxSelectedChain, implementor, existingQCI, transactions, author, createQCIMutation, updateQCIMutation, navigate, editorFrontmatter, serializedTxsForCounter, editorBodyLimit]
   );
 
   const handlePreview = () => {
@@ -445,85 +641,14 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
           />
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="content">Proposal Content (Markdown) *</Label>
-          <Textarea
-            id="content"
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            required
-            rows={20}
-            className="font-mono text-sm"
-            placeholder={`## Summary
-
-Brief overview of your proposal...
-
-## Abstract
-
-Detailed explanation...
-
-## Rationale
-
-Why this proposal is needed...
-
-## Technical Specification
-
-Implementation details...`}
-          />
-          <div className="flex items-center justify-end gap-1.5">
-            <span
-              className={`text-xs ${
-                editorOverLimit
-                  ? "text-destructive"
-                  : editorNearLimit
-                  ? "text-amber-600 dark:text-amber-400"
-                  : "text-muted-foreground"
-              }`}
-              aria-live="polite"
-              title="Advisory projection — final count is checked at Snapshot submit."
-            >
-              Snapshot body: {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()} chars
-              {editorOverLimit && " — over Snapshot limit"}
-            </span>
-            <TooltipProvider delayDuration={150}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Snapshot body character breakdown"
-                    className="text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    <Info className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top" align="end" className="max-w-xs">
-                  <div className="space-y-1.5">
-                    <div className="font-semibold">Snapshot body breakdown</div>
-                    <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5 text-xs">
-                      <span>YAML frontmatter</span>
-                      <span className="text-right tabular-nums">{frontmatterChars.toLocaleString()}</span>
-                      <span>Proposal content</span>
-                      <span className="text-right tabular-nums">{contentChars.toLocaleString()}</span>
-                      {txCharContribution > 0 && (
-                        <>
-                          <span>Transactions block</span>
-                          <span className="text-right tabular-nums">{txCharContribution.toLocaleString()}</span>
-                        </>
-                      )}
-                      <span className="border-t border-primary-foreground/20 pt-0.5 font-medium">Total</span>
-                      <span className="border-t border-primary-foreground/20 pt-0.5 text-right font-medium tabular-nums">
-                        {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()}
-                      </span>
-                    </div>
-                    <div className="pt-1 text-[10px] opacity-80">
-                      Frontmatter and transactions are emitted by the Snapshot serializer in addition to your markdown content. Advisory projection — the submitter does the final check.
-                    </div>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-        </div>
+        <SnapshotBodySection
+          ref={bodyRef}
+          initialContent={initialContentValue}
+          frontmatter={editorFrontmatter}
+          serializedTxs={serializedTxsForCounter}
+          bodyLimit={editorBodyLimit}
+          onOverLimitChange={handleOverLimitChange}
+        />
 
         {/* Transactions Section */}
         <div className="space-y-2">
@@ -569,11 +694,11 @@ Implementation details...`}
         </div>
 
         <div className="flex space-x-4">
-          <Button type="submit" disabled={saving || editorOverLimit} variant="gradient-primary" size="lg">
+          <Button type="submit" disabled={saving || isContentOverLimit} variant="gradient-primary" size="lg">
             {saving
               ? "Saving..."
-              : editorOverLimit
-              ? `Body over Snapshot limit (${editorBodyLength.toLocaleString()} / ${editorBodyLimit.toLocaleString()})`
+              : isContentOverLimit
+              ? `Body over Snapshot limit (${editorBodyLimit.toLocaleString()})`
               : existingQCI
               ? "Update QCI"
               : "Create QCI"}
@@ -594,7 +719,7 @@ Implementation details...`}
               <span>Chain: {combooxSelectedChain}</span> •<span> Author: {author || address}</span> •<span> Status: Draft</span>
             </div>
             <div className="prose dark:prose-invert max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{previewContent}</ReactMarkdown>
             </div>
 
             {/* Show transactions in preview */}

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAccount, useWalletClient, useSwitchChain } from 'wagmi';
@@ -17,11 +17,18 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { TransactionFormatter } from "./TransactionFormatter";
 import { TransactionGroup } from "./TransactionGroup";
 import { type TransactionData, ABIParser } from "../utils/abiParser";
-import { groupTransactionsByMultisig } from "../utils/transactionParser";
+import { groupTransactionsByMultisig, serializeTransactionsForBody } from "../utils/transactionParser";
+import { formatProposalBody } from "../utils/snapshotPayload";
 import { Plus } from "lucide-react";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { getAllChainNames } from '@/config/proposalChains';
+
+// Warning threshold for the advisory counter — render amber at 80% of the
+// limit, destructive (red) above the limit. Matches CommentComposer's
+// canonical pattern. Editor doesn't enforce; the hard gate lives in the
+// submitter. Tooltip on the counter explains the advisory nature.
+const EDITOR_BODY_WARNING_RATIO = 0.8;
 
 interface ProposalEditorProps {
   registryAddress: Address;
@@ -98,6 +105,35 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   // Initialize mutation hooks
   const createQCIMutation = useCreateQCI({ registryAddress });
   const updateQCIMutation = useUpdateQCI({ registryAddress });
+
+  // Advisory projection of the Snapshot body the user is composing. Routes
+  // through the same shared serializer (formatProposalBody +
+  // serializeTransactionsForBody) the submitter uses at signature time —
+  // single shared serializer, no parallel size-accounting path. R3 calls
+  // for this counter as an early-feedback signal; the hard gate lives in
+  // SnapshotSubmitter so editing doesn't get blocked on a QCI save (which
+  // writes to IPFS + registry, neither of which has the Snapshot limit).
+  //
+  // Pessimistic in two small ways: when implementor / implementation-date
+  // are unset, we emit "None" so the frontmatter row is omitted (matching
+  // the submitter's behavior); and we fall back to today's date for
+  // created if no existing QCI is loaded.
+  const projectedEmbeddedBody = useMemo(() => {
+    const frontmatter = {
+      chain: combooxSelectedChain,
+      author: author || "",
+      implementor,
+      "implementation-date": existingQCI?.content["implementation-date"] || "None",
+      created: existingQCI?.content.created || new Date().toISOString().split("T")[0],
+    };
+    const serializedTxs = serializeTransactionsForBody(transactions);
+    return formatProposalBody(content, frontmatter, serializedTxs);
+  }, [content, combooxSelectedChain, author, implementor, existingQCI, transactions]);
+  const editorBodyLength = projectedEmbeddedBody.length;
+  const editorBodyLimit = config.snapshotBodyLimitDefault;
+  const editorOverLimit = editorBodyLength > editorBodyLimit;
+  const editorNearLimit =
+    !editorOverLimit && editorBodyLength >= Math.floor(editorBodyLimit * EDITOR_BODY_WARNING_RATIO);
 
   // Initialize transactions from existing QCI content
   useEffect(() => {
@@ -181,20 +217,11 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
       setSaving(true);
 
       try {
-        // Group transactions by multisig address
-        const transactionGroups = groupTransactionsByMultisig(transactions).map(group => ({
-          multisig: group.multisig,
-          transactions: group.transactions.map((tx) => {
-            // Parse the formatted transaction and add it back
-            const formatted = ABIParser.formatTransaction(tx);
-            return JSON.parse(formatted);
-          }),
-        }));
-
-        // Serialize transaction groups as string for QCIContent
-        const serializedTransactions = transactions.length > 0
-          ? JSON.stringify(transactionGroups, null, 2)
-          : undefined;
+        // Serialize transaction groups as a string for QCIContent. The same
+        // helper is used by the advisory counter below so the editor's
+        // projected Snapshot-body length matches what eventually goes on the
+        // wire — single shared serializer, no parallel path.
+        const serializedTransactions = serializeTransactionsForBody(transactions);
 
         // Create QCI content object
         const qciContent: QCIContent = {
@@ -401,6 +428,26 @@ Why this proposal is needed...
 
 Implementation details...`}
           />
+          {/* Advisory Snapshot-body counter — informational only, no gating.
+              Routes through the same shared serializer the submitter uses;
+              tooltip clarifies that the authoritative check happens at
+              Snapshot submission. */}
+          <div className="flex items-center justify-end text-xs">
+            <span
+              className={
+                editorOverLimit
+                  ? "text-destructive"
+                  : editorNearLimit
+                  ? "text-amber-600 dark:text-amber-400"
+                  : "text-muted-foreground"
+              }
+              aria-live="polite"
+              title="Advisory projection — final count is checked at Snapshot submit."
+            >
+              Snapshot body: {editorBodyLength.toLocaleString()} / {editorBodyLimit.toLocaleString()} chars
+              {editorOverLimit && " — over Snapshot limit"}
+            </span>
+          </div>
         </div>
 
         {/* Transactions Section */}

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -114,17 +114,31 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   );
   const existingImplementationDate = existingQCI?.content["implementation-date"];
   const existingCreated = existingQCI?.content.created;
-  const projectedEmbeddedBody = useMemo(() => {
-    const frontmatter = {
+  const editorFrontmatter = useMemo(
+    () => ({
       chain: combooxSelectedChain,
       author: author || "",
       implementor,
       "implementation-date": existingImplementationDate || "None",
       created: existingCreated || new Date().toISOString().split("T")[0],
-    };
-    return formatProposalBody(content, frontmatter, serializedTxsForCounter);
-  }, [content, combooxSelectedChain, author, implementor, existingImplementationDate, existingCreated, serializedTxsForCounter]);
+    }),
+    [combooxSelectedChain, author, implementor, existingImplementationDate, existingCreated]
+  );
+  const projectedEmbeddedBody = useMemo(
+    () => formatProposalBody(content, editorFrontmatter, serializedTxsForCounter),
+    [content, editorFrontmatter, serializedTxsForCounter]
+  );
+  // Body without the transactions section — used to compute the tx-only
+  // char contribution so the editor can show "Transactions: +N chars" next
+  // to the Transactions header. Avoids the user wondering where the bulk
+  // of the body length is coming from when txs are collapsed into "N
+  // transactions" in the UI.
+  const projectedBodyWithoutTxs = useMemo(
+    () => formatProposalBody(content, editorFrontmatter, undefined),
+    [content, editorFrontmatter]
+  );
   const editorBodyLength = projectedEmbeddedBody.length;
+  const txCharContribution = projectedEmbeddedBody.length - projectedBodyWithoutTxs.length;
   const editorBodyLimit = config.snapshotBodyLimitDefault;
   const editorOverLimit = editorBodyLength > editorBodyLimit;
   const editorNearLimit =
@@ -453,7 +467,17 @@ Implementation details...`}
         {/* Transactions Section */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <Label>Transactions</Label>
+            <div className="flex items-baseline gap-2">
+              <Label>Transactions</Label>
+              {transactions.length > 0 && (
+                <span
+                  className="text-xs text-muted-foreground"
+                  title="Characters this transactions block contributes to the Snapshot body — when offload mode lands in PR-B, this is the bulk that gets reclaimed."
+                >
+                  +{txCharContribution.toLocaleString()} chars to Snapshot body
+                </span>
+              )}
+            </div>
             <Button
               type="button"
               onClick={() => {

--- a/src/components/ProposalEditor.tsx
+++ b/src/components/ProposalEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo, useDeferredValue } from 'react';
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAccount, useWalletClient, useSwitchChain } from 'wagmi';
@@ -125,9 +125,16 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
     }),
     [combooxSelectedChain, author, implementor, existingImplementationDate, existingCreated]
   );
+  // Defer the per-keystroke `content` value so the textarea stays responsive
+  // while the formatProposalBody projections (regex strips, string concat,
+  // tx serialization) run at a lower priority. React keeps the input
+  // urgent; the counter "catches up" between keystrokes. The submit-time
+  // gate in handleSubmit recomputes against the urgent `content` so a fast
+  // typist can't slip an over-limit save through during the deferred lag.
+  const deferredContent = useDeferredValue(content);
   const projectedEmbeddedBody = useMemo(
-    () => formatProposalBody(content, editorFrontmatter, serializedTxsForCounter),
-    [content, editorFrontmatter, serializedTxsForCounter]
+    () => formatProposalBody(deferredContent, editorFrontmatter, serializedTxsForCounter),
+    [deferredContent, editorFrontmatter, serializedTxsForCounter]
   );
   // Body without the transactions section — used to compute the tx-only
   // char contribution so the editor can show "Transactions: +N chars" next
@@ -135,8 +142,8 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
   // of the body length is coming from when txs are collapsed into "N
   // transactions" in the UI.
   const projectedBodyWithoutTxs = useMemo(
-    () => formatProposalBody(content, editorFrontmatter, undefined),
-    [content, editorFrontmatter]
+    () => formatProposalBody(deferredContent, editorFrontmatter, undefined),
+    [deferredContent, editorFrontmatter]
   );
   // Empty-content baseline so we can attribute the YAML-frontmatter overhead
   // separately in the breakdown tooltip. formatProposalBody is additive
@@ -234,11 +241,15 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
 
       // A QCI saved over the Snapshot body limit can never be submitted to
       // Snapshot — block save here so we don't write wasted content to IPFS
-      // + the registry. The submitter has the same gate, but catching it at
-      // editor save is the kinder UX.
-      if (editorOverLimit) {
+      // + the registry. Recompute against the URGENT `content` value (not
+      // the deferred projection driving the visual counter) so a fast
+      // typist can't slip an over-limit save through during the deferred
+      // catch-up window. The submitter has its own authoritative gate, but
+      // catching it here is the kinder UX.
+      const freshBody = formatProposalBody(content, editorFrontmatter, serializedTxsForCounter);
+      if (freshBody.length > editorBodyLimit) {
         setError(
-          `Proposal body is ${editorBodyLength.toLocaleString()} chars — over Snapshot's ${editorBodyLimit.toLocaleString()}-char limit. Shorten before saving.`
+          `Proposal body is ${freshBody.length.toLocaleString()} chars — over Snapshot's ${editorBodyLimit.toLocaleString()}-char limit. Shorten before saving.`
         );
         return;
       }
@@ -333,7 +344,7 @@ export const ProposalEditor: React.FC<ProposalEditorProps> = ({
         setSaving(false);
       }
     },
-    [address, title, combooxSelectedChain, content, implementor, existingQCI, transactions, author, createQCIMutation, updateQCIMutation, navigate, editorOverLimit, editorBodyLength, editorBodyLimit]
+    [address, title, combooxSelectedChain, content, implementor, existingQCI, transactions, author, createQCIMutation, updateQCIMutation, navigate, editorFrontmatter, serializedTxsForCounter, editorBodyLimit]
   );
 
   const handlePreview = () => {

--- a/src/components/SnapshotSubmitter.tsx
+++ b/src/components/SnapshotSubmitter.tsx
@@ -132,6 +132,11 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
     );
     setStatusLevel("info");
 
+    // Hoisted so the catch block can read the actual sent body when
+    // classifying server errors (not the stale render-time projection).
+    // Undefined if an error fires before the body is built.
+    let wireBody: string | undefined;
+
     try {
       // Refetch to ensure we have the latest QIP number
       await refetchQipNumber();
@@ -164,7 +169,7 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
       // Recompute the wire body after refetchQipNumber — a digit-count
       // rollover (999 → 1000) adds one character to the title and can push
       // the body over the limit since the render-time projection.
-      const wireBody = formatProposalBody(rawMarkdown, frontmatter, transactions);
+      wireBody = formatProposalBody(rawMarkdown, frontmatter, transactions);
       if (wireBody.length > bodyLimit) {
         setBodyTooLongError({ delivered: wireBody.length, limit: bodyLimit });
         setStatus(null);
@@ -257,13 +262,22 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
       const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
       const isHttp4xx = typeof status === "number" && status >= 400 && status < 500;
 
+      // Prefer the actually-sent body length when available — projectedBody
+      // could be stale if frontmatter mutated between submit-click and catch.
+      const deliveredLength = wireBody !== undefined ? wireBody.length : projectedBody.length;
+
       if (lengthMatch) {
         const serverLimit = parseInt(lengthMatch[1], 10) || bodyLimit;
-        setBodyTooLongError({ delivered: projectedBody.length, limit: serverLimit });
+        setBodyTooLongError({ delivered: deliveredLength, limit: serverLimit });
         setStatus(null);
         setStatusLevel(null);
-      } else if (isClientError && isHttp4xx && projectedBody.length > bodyLimit) {
-        setBodyTooLongError({ delivered: projectedBody.length, limit: bodyLimit });
+      } else if (isClientError && isHttp4xx && wireBody !== undefined && wireBody.length > bodyLimit) {
+        // Heuristic fallback only fires when the body we ACTUALLY SENT was
+        // over the limit — using projectedBody here would mis-classify
+        // unrelated client errors (invalid space, bad timestamp, duplicate
+        // proposal) as "body too long" whenever the user had an over-limit
+        // draft visible in the editor.
+        setBodyTooLongError({ delivered: wireBody.length, limit: bodyLimit });
         setStatus(null);
         setStatusLevel(null);
       } else if (e.error && e.error_description) {

--- a/src/components/SnapshotSubmitter.tsx
+++ b/src/components/SnapshotSubmitter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useEthersSigner } from "../utils/ethers";
 import { createProposal } from "../utils/snapshotClient";
 import { Proposal } from "@snapshot-labs/snapshot.js/dist/src/sign/types";
@@ -8,6 +8,7 @@ import { config } from "../config";
 import { Card, CardContent, CardFooter } from "./ui/card";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
+import { Alert, AlertDescription } from "./ui/alert";
 import { AlertCircle, CheckCircle2, ExternalLink, Loader2 } from "lucide-react";
 import { base, mainnet } from "wagmi/chains";
 import { useLinkSnapshotProposal } from "../hooks/useLinkSnapshotProposal";
@@ -15,6 +16,28 @@ import { getLatestQipNumber } from "../utils/snapshotClient";
 import { useQITokenBalance } from "../hooks/useQITokenBalance";
 import { ChainSwitchRejectedError, useEnsureChain } from "../hooks/useEnsureChain";
 import { formatProposalBody } from "../utils/snapshotPayload";
+
+// Warning threshold: render the counter in amber when the projected body
+// reaches 80% of the limit. Below the threshold the counter stays muted;
+// above the limit it turns destructive (red) and the submit button locks.
+// Mirrors the canonical pattern from Comments/CommentComposer.tsx — the
+// only difference is the unit (characters here, UTF-8 bytes there) because
+// the Snapshot Sequencer gates on `body.length`, while the comments backend
+// gates on byte length.
+const WARNING_RATIO = 0.8;
+
+/**
+ * Structured local error type for Snapshot body-too-long rejections. Produced
+ * by the two-tier match in handleSubmit (primary regex on the Sequencer's
+ * `error_description`, plus a status+error-code heuristic that catches the
+ * same condition even if Snapshot drifts the error wording). Surfaces in the
+ * UI as a destructive Alert with the delivered/limit numbers so the user can
+ * shorten and retry.
+ */
+interface SnapshotBodyTooLongError {
+  delivered: number;
+  limit: number;
+}
 
 interface SnapshotSubmitterProps {
   frontmatter: any;
@@ -50,6 +73,7 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
   const [proposalId, setProposalId] = useState<string | null>(null);
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
   const [statusLevel, setStatusLevel] = useState<"info" | "success" | "error" | null>(null);
+  const [bodyTooLongError, setBodyTooLongError] = useState<SnapshotBodyTooLongError | null>(null);
 
   // Mutation hook for linking snapshot proposals
   const linkSnapshotMutation = useLinkSnapshotProposal({
@@ -89,12 +113,48 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
     return undefined;
   };
 
+  // Authoritative Snapshot body projection — the same string that goes on the
+  // wire if the user submits right now. R2 requires this counter to measure
+  // the wire payload, not the raw markdown, so we route through the shared
+  // serializer (R8 / Key Technical Decisions: single shared serializer). The
+  // counter and the actual snapshot.proposal() call both call this exact
+  // function; no parallel size-accounting path exists.
+  //
+  // `body.length` is UTF-16 code units — matches the Sequencer's
+  // `msg.payload.body.length` check, NOT UTF-8 bytes. Per R6.
+  const projectedBody = useMemo(
+    () => formatProposalBody(rawMarkdown, frontmatter, extractTransactions()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- extractTransactions reads from frontmatter
+    [rawMarkdown, frontmatter]
+  );
+  const bodyLength = projectedBody.length;
+  // qidao.eth lives in the "verified" bucket per the live GraphQL Settings
+  // query (verified=true, turbo=false). U7 (deferred) will hydrate this
+  // dynamically; for now the active limit is the default-bucket value.
+  const bodyLimit = config.snapshotBodyLimitDefault;
+  const overLimit = bodyLength > bodyLimit;
+  const nearLimit = !overLimit && bodyLength >= Math.floor(bodyLimit * WARNING_RATIO);
+
   const handleSubmit = async () => {
     if (!signer) {
       setStatus("Please connect your wallet first.");
       setStatusLevel("info");
       return;
     }
+
+    // Defensive: the submit button is also disabled when overLimit is true,
+    // but a parallel-state race (memo not yet flushed after a frontmatter
+    // mutation) could let a click through. Recompute and abort before any
+    // network or signature work fires.
+    if (projectedBody.length > bodyLimit) {
+      setBodyTooLongError({ delivered: projectedBody.length, limit: bodyLimit });
+      setStatus(null);
+      setStatusLevel(null);
+      return;
+    }
+
+    // Clear any prior structured body-too-long error from a previous attempt.
+    setBodyTooLongError(null);
     setLoading(true);
     setStatus(
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -133,11 +193,27 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
       // Extract transactions for the body
       const transactions = extractTransactions();
 
+      // Build the FINAL wire body using the now-refreshed QIP number. The
+      // earlier projectedBody memo used the render-time QIP number; if
+      // refetchQipNumber rolled the digit count over (999 → 1000), the
+      // title string grew by one character and the projected length is
+      // stale. Recompute from the same single shared serializer and
+      // abort BEFORE signature if the recomputed length now exceeds the
+      // limit. This is the parallel-read-path-safe gate site.
+      const wireBody = formatProposalBody(rawMarkdown, frontmatter, transactions);
+      if (wireBody.length > bodyLimit) {
+        setBodyTooLongError({ delivered: wireBody.length, limit: bodyLimit });
+        setStatus(null);
+        setStatusLevel(null);
+        setLoading(false);
+        return;
+      }
+
       const proposalOptions: Proposal = {
         space,
         type: "basic",
         title: qipTitle,
-        body: formatProposalBody(rawMarkdown, frontmatter, transactions),
+        body: wireBody,
         choices: ["For", "Against", "Abstain"],
         start: now + startOffset,
         end: now + endOffset,
@@ -203,14 +279,60 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
       }
     } catch (e: any) {
       console.error("Snapshot submission error:", e);
-      if (e.error && e.error_description) {
+
+      // Two-tier body-too-long detection.
+      //
+      // Primary: regex on the Sequencer's `error_description` field. The
+      // Sequencer's writer (snapshot-labs/sx-monorepo/apps/sequencer/src/
+      // writer/proposal.ts) returns the exact string
+      // "proposal body length can not exceed N characters" today, but treat
+      // upstream wording as drift-prone — Snapshot is an external dependency
+      // we don't version against.
+      //
+      // Secondary: if `error_description` is missing or the regex doesn't
+      // match but the response is shaped like a Sequencer client-side
+      // rejection (HTTP 4xx + `error === "client_error"`), AND the wire
+      // body we built locally exceeded the configured limit, surface the
+      // same structured CTA using the local limit as the assumed bound.
+      // The wire body length isn't available here — we re-derive it from
+      // the now-stale projectedBody, which is close enough for an
+      // assumed-limit display.
+      //
+      // Both paths read defensively: try error_description first, fall
+      // through to error.message, then to a stringified fallback.
+      const errorString: string =
+        (typeof e.error_description === "string" && e.error_description) ||
+        (typeof e.message === "string" && e.message) ||
+        (e !== null && e !== undefined ? String(e) : "");
+      const lengthMatch = errorString.match(/proposal body length can not exceed (\d+) characters/i);
+
+      const isClientError = typeof e.error === "string" && e.error === "client_error";
+      const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
+      const isHttp4xx = typeof status === "number" && status >= 400 && status < 500;
+
+      if (lengthMatch) {
+        // Primary match: extract the server-reported limit verbatim.
+        const serverLimit = parseInt(lengthMatch[1], 10) || bodyLimit;
+        setBodyTooLongError({ delivered: projectedBody.length, limit: serverLimit });
+        setStatus(null);
+        setStatusLevel(null);
+      } else if (isClientError && isHttp4xx && projectedBody.length > bodyLimit) {
+        // Heuristic fallback: a Sequencer client-error with a 4xx status
+        // and a body we know to be over the local limit — same condition,
+        // just different wording.
+        setBodyTooLongError({ delivered: projectedBody.length, limit: bodyLimit });
+        setStatus(null);
+        setStatusLevel(null);
+      } else if (e.error && e.error_description) {
         setStatus(`Error: ${e.error_description}`);
+        setStatusLevel("error");
       } else if (e.code === "ACTION_REJECTED" || e.code === 4001) {
         setStatus("Transaction cancelled by user");
+        setStatusLevel("error");
       } else {
         setStatus(`Error: ${e.message || "Failed to create proposal. Please try again."}`);
+        setStatusLevel("error");
       }
-      setStatusLevel("error");
     } finally {
       setLoading(false);
     }
@@ -356,6 +478,45 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
           </div>
         )}
 
+        {/* Body-too-long structured error. Renders when the Snapshot
+            Sequencer rejected the submission with a body-length error
+            (primary regex match) or when the heuristic fallback fires.
+            PR-B will extend this with an "Enable IPFS offload" CTA button;
+            for now the message gives the user the limit info so they can
+            shorten and retry. */}
+        {bodyTooLongError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              Snapshot rejected this body as too long (delivered{" "}
+              {bodyTooLongError.delivered.toLocaleString()} chars, limit{" "}
+              {bodyTooLongError.limit.toLocaleString()}). Shorten the title or proposal body and retry.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Live character counter — measures the authoritative wire payload
+            (the same string handleSubmit will send) via formatProposalBody.
+            Hidden when the QIP number is still loading because the projected
+            length depends on the QIP number in the title. */}
+        {!isLoadingQipNumber && (
+          <div className="flex items-center justify-between text-xs">
+            <span
+              className={
+                overLimit
+                  ? "text-destructive"
+                  : nearLimit
+                  ? "text-amber-600 dark:text-amber-400"
+                  : "text-muted-foreground"
+              }
+              aria-live="polite"
+            >
+              Snapshot body: {bodyLength.toLocaleString()} / {bodyLimit.toLocaleString()} chars
+              {overLimit && " — too long"}
+            </span>
+          </div>
+        )}
+
         {/* Prerequisites Info */}
         {signer && requiresTokenBalance && tokenBalance >= requiredBalance && (
           <div className="space-y-2">
@@ -404,7 +565,11 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
         <Button
           onClick={handleSubmit}
           disabled={
-            !signer || (requiresTokenBalance && tokenBalance < requiredBalance) || loading || (requiresTokenBalance && checkingBalance)
+            !signer ||
+            (requiresTokenBalance && tokenBalance < requiredBalance) ||
+            loading ||
+            (requiresTokenBalance && checkingBalance) ||
+            overLimit
           }
           className="w-full"
           size="xl"
@@ -418,6 +583,8 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
             ? "Connect Wallet"
             : requiresTokenBalance && tokenBalance < requiredBalance
             ? `Insufficient Balance (${tokenBalance.toLocaleString()} / ${requiredBalance.toLocaleString()} required)`
+            : overLimit
+            ? `Body too long (${bodyLength.toLocaleString()} / ${bodyLimit.toLocaleString()} chars)`
             : isTestMode
             ? `Submit Test QIP to ${SNAPSHOT_SPACE}`
             : `Submit QIP to ${SNAPSHOT_SPACE}`}

--- a/src/components/SnapshotSubmitter.tsx
+++ b/src/components/SnapshotSubmitter.tsx
@@ -16,24 +16,8 @@ import { getLatestQipNumber } from "../utils/snapshotClient";
 import { useQITokenBalance } from "../hooks/useQITokenBalance";
 import { ChainSwitchRejectedError, useEnsureChain } from "../hooks/useEnsureChain";
 import { formatProposalBody } from "../utils/snapshotPayload";
+import { SNAPSHOT_BODY_WARNING_RATIO } from "../config/env";
 
-// Warning threshold: render the counter in amber when the projected body
-// reaches 80% of the limit. Below the threshold the counter stays muted;
-// above the limit it turns destructive (red) and the submit button locks.
-// Mirrors the canonical pattern from Comments/CommentComposer.tsx — the
-// only difference is the unit (characters here, UTF-8 bytes there) because
-// the Snapshot Sequencer gates on `body.length`, while the comments backend
-// gates on byte length.
-const WARNING_RATIO = 0.8;
-
-/**
- * Structured local error type for Snapshot body-too-long rejections. Produced
- * by the two-tier match in handleSubmit (primary regex on the Sequencer's
- * `error_description`, plus a status+error-code heuristic that catches the
- * same condition even if Snapshot drifts the error wording). Surfaces in the
- * UI as a destructive Alert with the delivered/limit numbers so the user can
- * shorten and retry.
- */
 interface SnapshotBodyTooLongError {
   delivered: number;
   limit: number;
@@ -113,27 +97,17 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
     return undefined;
   };
 
-  // Authoritative Snapshot body projection — the same string that goes on the
-  // wire if the user submits right now. R2 requires this counter to measure
-  // the wire payload, not the raw markdown, so we route through the shared
-  // serializer (R8 / Key Technical Decisions: single shared serializer). The
-  // counter and the actual snapshot.proposal() call both call this exact
-  // function; no parallel size-accounting path exists.
-  //
-  // `body.length` is UTF-16 code units — matches the Sequencer's
-  // `msg.payload.body.length` check, NOT UTF-8 bytes. Per R6.
+  // Memoize the wire body so the counter and the submit guard read the same
+  // string without re-serializing on every render. `qidao.eth` lives in the
+  // "verified" bucket which maps to the default limit.
   const projectedBody = useMemo(
-    () => formatProposalBody(rawMarkdown, frontmatter, extractTransactions()),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- extractTransactions reads from frontmatter
+    () => formatProposalBody(rawMarkdown, frontmatter, frontmatter.transactions),
     [rawMarkdown, frontmatter]
   );
   const bodyLength = projectedBody.length;
-  // qidao.eth lives in the "verified" bucket per the live GraphQL Settings
-  // query (verified=true, turbo=false). U7 (deferred) will hydrate this
-  // dynamically; for now the active limit is the default-bucket value.
   const bodyLimit = config.snapshotBodyLimitDefault;
   const overLimit = bodyLength > bodyLimit;
-  const nearLimit = !overLimit && bodyLength >= Math.floor(bodyLimit * WARNING_RATIO);
+  const nearLimit = !overLimit && bodyLength >= Math.floor(bodyLimit * SNAPSHOT_BODY_WARNING_RATIO);
 
   const handleSubmit = async () => {
     if (!signer) {
@@ -142,18 +116,12 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
       return;
     }
 
-    // Defensive: the submit button is also disabled when overLimit is true,
-    // but a parallel-state race (memo not yet flushed after a frontmatter
-    // mutation) could let a click through. Recompute and abort before any
-    // network or signature work fires.
     if (projectedBody.length > bodyLimit) {
       setBodyTooLongError({ delivered: projectedBody.length, limit: bodyLimit });
       setStatus(null);
       setStatusLevel(null);
       return;
     }
-
-    // Clear any prior structured body-too-long error from a previous attempt.
     setBodyTooLongError(null);
     setLoading(true);
     setStatus(
@@ -193,13 +161,9 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
       // Extract transactions for the body
       const transactions = extractTransactions();
 
-      // Build the FINAL wire body using the now-refreshed QIP number. The
-      // earlier projectedBody memo used the render-time QIP number; if
-      // refetchQipNumber rolled the digit count over (999 → 1000), the
-      // title string grew by one character and the projected length is
-      // stale. Recompute from the same single shared serializer and
-      // abort BEFORE signature if the recomputed length now exceeds the
-      // limit. This is the parallel-read-path-safe gate site.
+      // Recompute the wire body after refetchQipNumber — a digit-count
+      // rollover (999 → 1000) adds one character to the title and can push
+      // the body over the limit since the render-time projection.
       const wireBody = formatProposalBody(rawMarkdown, frontmatter, transactions);
       if (wireBody.length > bodyLimit) {
         setBodyTooLongError({ delivered: wireBody.length, limit: bodyLimit });
@@ -280,46 +244,25 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
     } catch (e: any) {
       console.error("Snapshot submission error:", e);
 
-      // Two-tier body-too-long detection.
-      //
-      // Primary: regex on the Sequencer's `error_description` field. The
-      // Sequencer's writer (snapshot-labs/sx-monorepo/apps/sequencer/src/
-      // writer/proposal.ts) returns the exact string
-      // "proposal body length can not exceed N characters" today, but treat
-      // upstream wording as drift-prone — Snapshot is an external dependency
-      // we don't version against.
-      //
-      // Secondary: if `error_description` is missing or the regex doesn't
-      // match but the response is shaped like a Sequencer client-side
-      // rejection (HTTP 4xx + `error === "client_error"`), AND the wire
-      // body we built locally exceeded the configured limit, surface the
-      // same structured CTA using the local limit as the assumed bound.
-      // The wire body length isn't available here — we re-derive it from
-      // the now-stale projectedBody, which is close enough for an
-      // assumed-limit display.
-      //
-      // Both paths read defensively: try error_description first, fall
-      // through to error.message, then to a stringified fallback.
+      // Two-tier body-too-long detection: primary is the Sequencer's
+      // `error_description` string (the canonical signal but drift-prone
+      // since Snapshot is external); secondary is HTTP 4xx + client-error
+      // shape (resilient to wording changes upstream).
       const errorString: string =
         (typeof e.error_description === "string" && e.error_description) ||
         (typeof e.message === "string" && e.message) ||
         (e !== null && e !== undefined ? String(e) : "");
       const lengthMatch = errorString.match(/proposal body length can not exceed (\d+) characters/i);
-
       const isClientError = typeof e.error === "string" && e.error === "client_error";
       const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
       const isHttp4xx = typeof status === "number" && status >= 400 && status < 500;
 
       if (lengthMatch) {
-        // Primary match: extract the server-reported limit verbatim.
         const serverLimit = parseInt(lengthMatch[1], 10) || bodyLimit;
         setBodyTooLongError({ delivered: projectedBody.length, limit: serverLimit });
         setStatus(null);
         setStatusLevel(null);
       } else if (isClientError && isHttp4xx && projectedBody.length > bodyLimit) {
-        // Heuristic fallback: a Sequencer client-error with a 4xx status
-        // and a body we know to be over the local limit — same condition,
-        // just different wording.
         setBodyTooLongError({ delivered: projectedBody.length, limit: bodyLimit });
         setStatus(null);
         setStatusLevel(null);
@@ -478,12 +421,6 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
           </div>
         )}
 
-        {/* Body-too-long structured error. Renders when the Snapshot
-            Sequencer rejected the submission with a body-length error
-            (primary regex match) or when the heuristic fallback fires.
-            PR-B will extend this with an "Enable IPFS offload" CTA button;
-            for now the message gives the user the limit info so they can
-            shorten and retry. */}
         {bodyTooLongError && (
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
@@ -495,26 +432,20 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
           </Alert>
         )}
 
-        {/* Live character counter — measures the authoritative wire payload
-            (the same string handleSubmit will send) via formatProposalBody.
-            Hidden when the QIP number is still loading because the projected
-            length depends on the QIP number in the title. */}
         {!isLoadingQipNumber && (
-          <div className="flex items-center justify-between text-xs">
-            <span
-              className={
-                overLimit
-                  ? "text-destructive"
-                  : nearLimit
-                  ? "text-amber-600 dark:text-amber-400"
-                  : "text-muted-foreground"
-              }
-              aria-live="polite"
-            >
-              Snapshot body: {bodyLength.toLocaleString()} / {bodyLimit.toLocaleString()} chars
-              {overLimit && " — too long"}
-            </span>
-          </div>
+          <span
+            className={`text-xs ${
+              overLimit
+                ? "text-destructive"
+                : nearLimit
+                ? "text-amber-600 dark:text-amber-400"
+                : "text-muted-foreground"
+            }`}
+            aria-live="polite"
+          >
+            Snapshot body: {bodyLength.toLocaleString()} / {bodyLimit.toLocaleString()} chars
+            {overLimit && " — too long"}
+          </span>
         )}
 
         {/* Prerequisites Info */}

--- a/src/components/SnapshotSubmitter.tsx
+++ b/src/components/SnapshotSubmitter.tsx
@@ -14,6 +14,7 @@ import { useLinkSnapshotProposal } from "../hooks/useLinkSnapshotProposal";
 import { getLatestQipNumber } from "../utils/snapshotClient";
 import { useQITokenBalance } from "../hooks/useQITokenBalance";
 import { ChainSwitchRejectedError, useEnsureChain } from "../hooks/useEnsureChain";
+import { formatProposalBody } from "../utils/snapshotPayload";
 
 interface SnapshotSubmitterProps {
   frontmatter: any;
@@ -76,104 +77,6 @@ const SnapshotSubmitter: React.FC<SnapshotSubmitterProps> = ({
 
   // Use global QI token balance hook (pre-cached on site load)
   const { tokenBalance, isLoading: checkingBalance, requiresTokenBalance, requiredBalance } = useQITokenBalance();
-
-  const formatProposalBody = (rawMarkdown: string, frontmatter: any, transactions?: string | string[]) => {
-    // Remove frontmatter from the beginning of the markdown
-    let content = rawMarkdown.replace(/^---[\s\S]*?---\n?/, "").trim();
-
-    // Remove title if it appears at the beginning of the content
-    // This handles various title formats like "## QIP247 Title" or "## **QIP247 Title**"
-    content = content.replace(/^##\s*\*?\*?QIP\d+[:\s].*?\*?\*?\n+/i, "");
-
-    // Build YAML frontmatter for the proposal body
-    const yamlFields = [];
-    yamlFields.push("---");
-
-    // Use "network" instead of "chain"
-    if (frontmatter.chain) {
-      yamlFields.push(`network: ${frontmatter.chain}`);
-    }
-
-    if (frontmatter.author) {
-      yamlFields.push(`author: ${frontmatter.author}`);
-    }
-
-    // Only include implementor if it's not "None"
-    if (frontmatter.implementor && frontmatter.implementor !== "None") {
-      yamlFields.push(`implementor: ${frontmatter.implementor}`);
-    }
-
-    // Only include implementation-date if it's not "None"
-    if (frontmatter["implementation-date"] && frontmatter["implementation-date"] !== "None") {
-      yamlFields.push(`implementation-date: ${frontmatter["implementation-date"]}`);
-    }
-
-    if (frontmatter.created) {
-      yamlFields.push(`created: ${frontmatter.created}`);
-    }
-
-    yamlFields.push("---");
-
-    // Build the full body with YAML frontmatter
-    let fullBody = yamlFields.join("\n") + "\n\n" + content;
-
-    // Add transactions if present - now supporting multisig-grouped format
-    if (transactions) {
-      fullBody += "\n\n## Transactions\n\n";
-
-      try {
-        let parsed: any;
-
-        // Handle both string (new) and string[] (old) formats
-        if (typeof transactions === 'string') {
-          // New format: direct string
-          parsed = JSON.parse(transactions);
-        } else if (Array.isArray(transactions) && transactions.length > 0) {
-          // Old format: string array
-          parsed = JSON.parse(transactions[0]);
-        } else {
-          // Invalid format
-          parsed = [];
-        }
-
-        // Check if it's the new multisig-grouped format
-        if (Array.isArray(parsed) && parsed.length > 0 && 'multisig' in parsed[0] && 'transactions' in parsed[0]) {
-          // New format: group by multisig
-          parsed.forEach((group: any, groupIndex: number) => {
-            if (group.multisig) {
-              fullBody += `### Multisig: \`${group.multisig}\`\n\n`;
-            }
-
-            group.transactions.forEach((tx: any, txIndex: number) => {
-              const txNum = groupIndex > 0 ? `${groupIndex + 1}.${txIndex + 1}` : `${txIndex + 1}`;
-              fullBody += `**Transaction ${txNum}**`;
-
-              // Add annotation if present
-              if (tx.annotation) {
-                fullBody += `\n\n*${tx.annotation}*`;
-              }
-
-              fullBody += `\n\n\`\`\`json\n${JSON.stringify(tx, null, 2)}\n\`\`\`\n\n`;
-            });
-          });
-        } else if (Array.isArray(parsed)) {
-          // Legacy format: simple array of transactions
-          parsed.forEach((tx: any, index: number) => {
-            fullBody += `### Transaction ${index + 1}\n\`\`\`json\n${JSON.stringify(tx, null, 2)}\n\`\`\`\n\n`;
-          });
-        }
-      } catch (error) {
-        // Fallback: treat as legacy format string array
-        if (Array.isArray(transactions)) {
-          transactions.forEach((tx, index) => {
-            fullBody += `### Transaction ${index + 1}\n\`\`\`\n${tx}\n\`\`\`\n\n`;
-          });
-        }
-      }
-    }
-
-    return fullBody;
-  };
 
   const space = SNAPSHOT_SPACE;
 

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { config, getSnapshotBodyLimit } from "./env";
+
+// Tests for the Snapshot body-limit config and helper added in U2.
+// The `getEnvVar`/`parseInt` pipeline is already exercised by
+// `qipCommentsBodyMaxBytes` and other existing config keys; these tests pin
+// the new helper's bucket-selection contract.
+
+describe("Snapshot body-limit config", () => {
+  it("config.snapshotBodyLimitDefault is a positive integer", () => {
+    expect(typeof config.snapshotBodyLimitDefault).toBe("number");
+    expect(Number.isInteger(config.snapshotBodyLimitDefault)).toBe(true);
+    expect(config.snapshotBodyLimitDefault).toBeGreaterThan(0);
+  });
+
+  it("config.snapshotBodyLimitTurbo is a positive integer", () => {
+    expect(typeof config.snapshotBodyLimitTurbo).toBe("number");
+    expect(Number.isInteger(config.snapshotBodyLimitTurbo)).toBe(true);
+    expect(config.snapshotBodyLimitTurbo).toBeGreaterThan(0);
+  });
+
+  it("default limit is 10000 without env override (matches Snapshot Sequencer's default-bucket value)", () => {
+    // No env override in the test environment, so the parseInt fallback chain
+    // returns the default-default literal 10000.
+    expect(config.snapshotBodyLimitDefault).toBe(10000);
+  });
+
+  it("turbo limit is 50000 without env override (matches live DB value)", () => {
+    expect(config.snapshotBodyLimitTurbo).toBe(50000);
+  });
+});
+
+describe("getSnapshotBodyLimit", () => {
+  it("returns the default limit for 'default' bucket", () => {
+    expect(getSnapshotBodyLimit("default")).toBe(config.snapshotBodyLimitDefault);
+  });
+
+  it("returns the default limit for 'verified' bucket (qidao.eth's bucket)", () => {
+    expect(getSnapshotBodyLimit("verified")).toBe(config.snapshotBodyLimitDefault);
+  });
+
+  it("returns the default limit for 'flagged' bucket", () => {
+    expect(getSnapshotBodyLimit("flagged")).toBe(config.snapshotBodyLimitDefault);
+  });
+
+  it("returns the turbo limit for 'turbo' bucket", () => {
+    expect(getSnapshotBodyLimit("turbo")).toBe(config.snapshotBodyLimitTurbo);
+  });
+
+  it("turbo limit is strictly greater than default limit", () => {
+    // Documents the relationship between the two buckets — turbo (Snapshot Pro)
+    // is always at least as permissive as default. If this assertion ever fails
+    // because Snapshot inverts the buckets, the call sites in U5/U6 should be
+    // revisited to handle the new ordering.
+    expect(getSnapshotBodyLimit("turbo")).toBeGreaterThan(getSnapshotBodyLimit("verified"));
+  });
+});

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,57 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { config, getSnapshotBodyLimit } from "./env";
-
-// Tests for the Snapshot body-limit config and helper added in U2.
-// The `getEnvVar`/`parseInt` pipeline is already exercised by
-// `qipCommentsBodyMaxBytes` and other existing config keys; these tests pin
-// the new helper's bucket-selection contract.
+import { config, SNAPSHOT_BODY_WARNING_RATIO } from "./env";
 
 describe("Snapshot body-limit config", () => {
-  it("config.snapshotBodyLimitDefault is a positive integer", () => {
-    expect(typeof config.snapshotBodyLimitDefault).toBe("number");
-    expect(Number.isInteger(config.snapshotBodyLimitDefault)).toBe(true);
-    expect(config.snapshotBodyLimitDefault).toBeGreaterThan(0);
-  });
-
-  it("config.snapshotBodyLimitTurbo is a positive integer", () => {
-    expect(typeof config.snapshotBodyLimitTurbo).toBe("number");
-    expect(Number.isInteger(config.snapshotBodyLimitTurbo)).toBe(true);
-    expect(config.snapshotBodyLimitTurbo).toBeGreaterThan(0);
-  });
-
-  it("default limit is 10000 without env override (matches Snapshot Sequencer's default-bucket value)", () => {
-    // No env override in the test environment, so the parseInt fallback chain
-    // returns the default-default literal 10000.
+  it("config.snapshotBodyLimitDefault defaults to 10000 (Snapshot Sequencer's default bucket)", () => {
     expect(config.snapshotBodyLimitDefault).toBe(10000);
   });
 
-  it("turbo limit is 50000 without env override (matches live DB value)", () => {
+  it("config.snapshotBodyLimitTurbo defaults to 50000 (live DB value)", () => {
     expect(config.snapshotBodyLimitTurbo).toBe(50000);
-  });
-});
-
-describe("getSnapshotBodyLimit", () => {
-  it("returns the default limit for 'default' bucket", () => {
-    expect(getSnapshotBodyLimit("default")).toBe(config.snapshotBodyLimitDefault);
-  });
-
-  it("returns the default limit for 'verified' bucket (qidao.eth's bucket)", () => {
-    expect(getSnapshotBodyLimit("verified")).toBe(config.snapshotBodyLimitDefault);
-  });
-
-  it("returns the default limit for 'flagged' bucket", () => {
-    expect(getSnapshotBodyLimit("flagged")).toBe(config.snapshotBodyLimitDefault);
-  });
-
-  it("returns the turbo limit for 'turbo' bucket", () => {
-    expect(getSnapshotBodyLimit("turbo")).toBe(config.snapshotBodyLimitTurbo);
   });
 
   it("turbo limit is strictly greater than default limit", () => {
-    // Documents the relationship between the two buckets — turbo (Snapshot Pro)
-    // is always at least as permissive as default. If this assertion ever fails
-    // because Snapshot inverts the buckets, the call sites in U5/U6 should be
-    // revisited to handle the new ordering.
-    expect(getSnapshotBodyLimit("turbo")).toBeGreaterThan(getSnapshotBodyLimit("verified"));
+    expect(config.snapshotBodyLimitTurbo).toBeGreaterThan(config.snapshotBodyLimitDefault);
+  });
+
+  it("SNAPSHOT_BODY_WARNING_RATIO is a fraction between 0 and 1", () => {
+    expect(SNAPSHOT_BODY_WARNING_RATIO).toBeGreaterThan(0);
+    expect(SNAPSHOT_BODY_WARNING_RATIO).toBeLessThan(1);
   });
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -72,13 +72,10 @@ export const config = {
   snapshotTestMode: getBoolEnvVar("VITE_SNAPSHOT_TEST_MODE", false),
   snapshotTestSpace: getEnvVar("VITE_SNAPSHOT_TEST_SPACE", "testdevtest.eth"),
 
-  // Snapshot proposal-body character limit. Mirrors the bucketed limit the
-  // Snapshot Sequencer enforces server-side
-  // (snapshot-labs/sx-monorepo/apps/sequencer/src/writer/proposal.ts:260-264).
-  // Counted as JavaScript string.length (UTF-16 code units), NOT UTF-8 bytes.
-  // Default bucket (verified/default/flagged spaces, including qidao.eth) =
-  // 10000; turbo (Snapshot Pro) spaces = 50000 per live DB. Override via env
-  // var if Snapshot bumps the limits before this client is redeployed.
+  // Snapshot proposal-body character limit. Counted as `.length` (UTF-16
+  // code units) to match the Sequencer's own check, NOT UTF-8 bytes —
+  // unlike `qipCommentsBodyMaxBytes` above which gates on bytes because
+  // the comments backend does. The default bucket covers qidao.eth.
   snapshotBodyLimitDefault: parseInt(getEnvVar("VITE_SNAPSHOT_BODY_LIMIT_DEFAULT", "10000"), 10) || 10000,
   snapshotBodyLimitTurbo: parseInt(getEnvVar("VITE_SNAPSHOT_BODY_LIMIT_TURBO", "50000"), 10) || 50000,
 
@@ -87,22 +84,11 @@ export const config = {
   isProduction: process.env.NODE_ENV === "production",
 };
 
-/**
- * Snapshot space-type bucket. Mirrors how the Sequencer keys its body-limit
- * options in MySQL: `space.{default,verified,flagged,turbo}.body_limit`. Default,
- * verified, and flagged all map to the same default limit; turbo is the higher
- * Snapshot Pro tier. U7 (deferred) will hydrate this from the live Settings
- * query; until then the active call site passes "verified" as the literal type
- * for qidao.eth (verified live: space(id: "qidao.eth").verified == true).
- */
-export type SnapshotSpaceType = "default" | "verified" | "flagged" | "turbo";
-
-export const getSnapshotBodyLimit = (spaceType: SnapshotSpaceType): number => {
-  if (spaceType === "turbo") {
-    return config.snapshotBodyLimitTurbo;
-  }
-  return config.snapshotBodyLimitDefault;
-};
+// Warning threshold for the live Snapshot-body counter — render amber at
+// 80% of the configured limit, destructive above it. Shared between the
+// authoritative counter in SnapshotSubmitter and the advisory counter in
+// ProposalEditor so the boundary stays consistent.
+export const SNAPSHOT_BODY_WARNING_RATIO = 0.8;
 
 // Validation
 export const validateConfig = () => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -72,9 +72,36 @@ export const config = {
   snapshotTestMode: getBoolEnvVar("VITE_SNAPSHOT_TEST_MODE", false),
   snapshotTestSpace: getEnvVar("VITE_SNAPSHOT_TEST_SPACE", "testdevtest.eth"),
 
+  // Snapshot proposal-body character limit. Mirrors the bucketed limit the
+  // Snapshot Sequencer enforces server-side
+  // (snapshot-labs/sx-monorepo/apps/sequencer/src/writer/proposal.ts:260-264).
+  // Counted as JavaScript string.length (UTF-16 code units), NOT UTF-8 bytes.
+  // Default bucket (verified/default/flagged spaces, including qidao.eth) =
+  // 10000; turbo (Snapshot Pro) spaces = 50000 per live DB. Override via env
+  // var if Snapshot bumps the limits before this client is redeployed.
+  snapshotBodyLimitDefault: parseInt(getEnvVar("VITE_SNAPSHOT_BODY_LIMIT_DEFAULT", "10000"), 10) || 10000,
+  snapshotBodyLimitTurbo: parseInt(getEnvVar("VITE_SNAPSHOT_BODY_LIMIT_TURBO", "50000"), 10) || 50000,
+
   // Development Configuration
   isDevelopment: process.env.NODE_ENV === "development",
   isProduction: process.env.NODE_ENV === "production",
+};
+
+/**
+ * Snapshot space-type bucket. Mirrors how the Sequencer keys its body-limit
+ * options in MySQL: `space.{default,verified,flagged,turbo}.body_limit`. Default,
+ * verified, and flagged all map to the same default limit; turbo is the higher
+ * Snapshot Pro tier. U7 (deferred) will hydrate this from the live Settings
+ * query; until then the active call site passes "verified" as the literal type
+ * for qidao.eth (verified live: space(id: "qidao.eth").verified == true).
+ */
+export type SnapshotSpaceType = "default" | "verified" | "flagged" | "turbo";
+
+export const getSnapshotBodyLimit = (spaceType: SnapshotSpaceType): number => {
+  if (spaceType === "turbo") {
+    return config.snapshotBodyLimitTurbo;
+  }
+  return config.snapshotBodyLimitDefault;
 };
 
 // Validation

--- a/src/utils/snapshotPayload.test.ts
+++ b/src/utils/snapshotPayload.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { formatProposalBody } from "./snapshotPayload";
 
-// Golden-fixture tests for the extracted formatProposalBody.
-// Per the PR-A plan: the extracted util must produce a byte-identical
-// Snapshot body string to the prior in-component implementation. These
-// fixtures exercise the same code paths used at submission time
-// (frontmatter rewriting, title stripping, transactions formatting).
+// Golden-fixture tests for the extracted formatProposalBody. The extracted
+// util must produce a byte-identical Snapshot body string to the prior
+// in-component implementation; these fixtures exercise the same code paths
+// used at submission time (frontmatter rewriting, title stripping,
+// transactions formatting).
 
 describe("formatProposalBody", () => {
   describe("happy path — small QCI, zero transactions", () => {

--- a/src/utils/snapshotPayload.test.ts
+++ b/src/utils/snapshotPayload.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "vitest";
+import { formatProposalBody } from "./snapshotPayload";
+
+// Golden-fixture tests for the extracted formatProposalBody.
+// Per the PR-A plan: the extracted util must produce a byte-identical
+// Snapshot body string to the prior in-component implementation. These
+// fixtures exercise the same code paths used at submission time
+// (frontmatter rewriting, title stripping, transactions formatting).
+
+describe("formatProposalBody", () => {
+  describe("happy path — small QCI, zero transactions", () => {
+    it("produces the expected body with frontmatter and stripped title", () => {
+      const rawMarkdown = [
+        "---",
+        "qci: 1",
+        "title: Test Proposal",
+        "chain: Polygon",
+        "author: alice.eth",
+        "created: 2026-05-21",
+        "---",
+        "## QIP1: Test Proposal",
+        "",
+        "This is the proposal body.",
+      ].join("\n");
+
+      const frontmatter = {
+        chain: "Polygon",
+        author: "alice.eth",
+        created: "2026-05-21",
+        title: "Test Proposal",
+      };
+
+      const result = formatProposalBody(rawMarkdown, frontmatter, undefined);
+
+      const expected = [
+        "---",
+        "network: Polygon",
+        "author: alice.eth",
+        "created: 2026-05-21",
+        "---",
+        "",
+        "This is the proposal body.",
+      ].join("\n");
+
+      expect(result).toBe(expected);
+    });
+
+    it("omits implementor and implementation-date when set to 'None'", () => {
+      const rawMarkdown = "---\n[frontmatter]\n---\n## QIP2: Title\n\nBody";
+      const frontmatter = {
+        chain: "Base",
+        author: "bob.eth",
+        implementor: "None",
+        "implementation-date": "None",
+        created: "2026-05-21",
+      };
+
+      const result = formatProposalBody(rawMarkdown, frontmatter, undefined);
+
+      expect(result).not.toContain("implementor:");
+      expect(result).not.toContain("implementation-date:");
+      expect(result).toContain("network: Base");
+      expect(result).toContain("author: bob.eth");
+    });
+
+    it("includes implementor and implementation-date when set to real values", () => {
+      const rawMarkdown = "---\n[frontmatter]\n---\n## QIP3: Title\n\nBody";
+      const frontmatter = {
+        chain: "Base",
+        author: "carol",
+        implementor: "operator-team",
+        "implementation-date": "2026-06-01",
+        created: "2026-05-21",
+      };
+
+      const result = formatProposalBody(rawMarkdown, frontmatter, undefined);
+
+      expect(result).toContain("implementor: operator-team");
+      expect(result).toContain("implementation-date: 2026-06-01");
+    });
+  });
+
+  describe("happy path — multisig-grouped transactions", () => {
+    it("renders ### Multisig: headers and Transaction N blocks for two groups and three txs", () => {
+      const rawMarkdown = "---\nqci: 100\n---\n## QIP100: Multi-tx test\n\nBody here.";
+      const frontmatter = {
+        chain: "Polygon",
+        author: "treasury",
+        created: "2026-05-21",
+      };
+
+      const transactions = JSON.stringify([
+        {
+          multisig: "0xMultisig1",
+          transactions: [
+            { chainId: 137, to: "0xTokenA", function: "transfer", args: ["100"], value: "0" },
+            { chainId: 137, to: "0xTokenA", function: "approve", args: ["0xSpender", "50"], value: "0", annotation: "for spender X" },
+          ],
+        },
+        {
+          multisig: "0xMultisig2",
+          transactions: [
+            { chainId: 137, to: "0xTokenB", function: "burn", args: [], value: "0" },
+          ],
+        },
+      ]);
+
+      const result = formatProposalBody(rawMarkdown, frontmatter, transactions);
+
+      // Body contains the frontmatter prefix and stripped title
+      expect(result).toContain("---\nnetwork: Polygon");
+      expect(result).toContain("Body here.");
+
+      // Transactions section header
+      expect(result).toContain("\n\n## Transactions\n\n");
+
+      // Multisig group headers
+      expect(result).toContain("### Multisig: `0xMultisig1`");
+      expect(result).toContain("### Multisig: `0xMultisig2`");
+
+      // Transaction numbering: first group uses bare N, subsequent groups use G.N
+      expect(result).toContain("**Transaction 1**");
+      expect(result).toContain("**Transaction 2**");
+      expect(result).toContain("**Transaction 2.1**");
+
+      // Annotation rendered as italic block
+      expect(result).toContain("*for spender X*");
+
+      // JSON code fences for each tx
+      expect(result).toMatch(/```json\n\{[\s\S]+?\}\n```/);
+    });
+  });
+
+  describe("edge case — empty transactions parameter", () => {
+    it("produces no trailing ## Transactions section when transactions is undefined", () => {
+      const result = formatProposalBody(
+        "---\n[fm]\n---\n## QIP5: Title\n\nBody",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        undefined
+      );
+
+      expect(result).not.toContain("## Transactions");
+      expect(result.endsWith("Body")).toBe(true);
+    });
+
+    it("produces no trailing gap when transactions is an empty string array", () => {
+      // Legacy string[] format with empty array — should not emit the Transactions section
+      const result = formatProposalBody(
+        "---\n[fm]\n---\n## QIP6: Title\n\nBody",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        []
+      );
+
+      // Empty array is falsy on .length check, so the if (transactions) branch
+      // takes the truthy path for an empty array (arrays are truthy in JS) —
+      // but the inner Array.isArray check finds length 0 and parsed defaults to [].
+      // The resulting body has the "## Transactions\n\n" header but no entries.
+      // This preserves the original behavior exactly; documenting it here.
+      expect(result).toContain("## Transactions");
+      // No transaction entries should follow.
+      expect(result).not.toContain("### Multisig:");
+      expect(result).not.toContain("**Transaction");
+      expect(result).not.toContain("### Transaction");
+    });
+  });
+
+  describe("edge case — non-ASCII frontmatter round-trips identically", () => {
+    it("preserves accented characters in author and implementor fields", () => {
+      const rawMarkdown = "---\n[fm]\n---\n## QIP7: Title\n\nBody";
+      const frontmatter = {
+        chain: "Polygon",
+        author: "Antônio café",
+        implementor: "François",
+        "implementation-date": "2026-06-15",
+        created: "2026-05-21",
+      };
+
+      const result = formatProposalBody(rawMarkdown, frontmatter, undefined);
+
+      expect(result).toContain("author: Antônio café");
+      expect(result).toContain("implementor: François");
+    });
+
+    it("preserves emoji in the body content", () => {
+      const rawMarkdown = "---\n[fm]\n---\n## QIP8: Title\n\nBody with 🎉 emoji";
+      const frontmatter = { chain: "Polygon", author: "a", created: "2026-05-21" };
+
+      const result = formatProposalBody(rawMarkdown, frontmatter, undefined);
+
+      expect(result).toContain("Body with 🎉 emoji");
+    });
+  });
+
+  describe("title stripping", () => {
+    it("strips a plain ## QIPxxx: heading", () => {
+      const rawMarkdown = "---\n[fm]\n---\n## QIP247: Plain heading\n\nBody only";
+      const result = formatProposalBody(rawMarkdown, { chain: "Polygon", created: "2026-05-21" }, undefined);
+
+      expect(result).not.toContain("QIP247");
+      expect(result).toContain("Body only");
+    });
+
+    it("strips a bold ## **QIPxxx Title** heading", () => {
+      const rawMarkdown = "---\n[fm]\n---\n## **QIP100 Bold heading**\n\nBody only";
+      const result = formatProposalBody(rawMarkdown, { chain: "Polygon", created: "2026-05-21" }, undefined);
+
+      expect(result).not.toContain("QIP100");
+      expect(result).toContain("Body only");
+    });
+  });
+
+  describe("legacy transactions format (string[])", () => {
+    it("handles legacy string-array of simple transactions", () => {
+      const txArray = [
+        JSON.stringify([
+          { chainId: 137, to: "0xA", function: "transfer", args: ["100"], value: "0" },
+          { chainId: 137, to: "0xB", function: "approve", args: ["0xSpender", "50"], value: "0" },
+        ]),
+      ];
+
+      const result = formatProposalBody(
+        "---\n[fm]\n---\n## QIP50: Legacy txs\n\nBody",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        txArray
+      );
+
+      expect(result).toContain("## Transactions");
+      expect(result).toContain("### Transaction 1");
+      expect(result).toContain("### Transaction 2");
+    });
+  });
+
+  describe("body-length measurement (Snapshot Sequencer-aligned)", () => {
+    it("returns a string whose .length matches the Snapshot Sequencer's check", () => {
+      // The Sequencer compares `msg.payload.body.length` against the configured
+      // limit. Call sites in U5/U6 must use .length directly (UTF-16 code units),
+      // NOT UTF-8 bytes. This test pins the contract: `formatProposalBody` returns
+      // a plain string; callers can measure it however they like.
+      const result = formatProposalBody(
+        "---\n[fm]\n---\n## QIP1: x\n\nShort body",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        undefined
+      );
+
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+      // Sanity: emoji in the body increments .length by 2 (surrogate pair) —
+      // this is the unit the server uses, and what U5/U6 must measure against.
+      // Both fixtures use the same title and trailing-newline shape so the
+      // title-stripping regex behaves identically; only the emoji differs.
+      const withEmoji = formatProposalBody(
+        "---\n[fm]\n---\n## QIP1: x\n\nHello 🎉 world\n",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        undefined
+      );
+      const withoutEmoji = formatProposalBody(
+        "---\n[fm]\n---\n## QIP1: x\n\nHello  world\n",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        undefined
+      );
+      // 🎉 is U+1F389, encoded as a UTF-16 surrogate pair (2 code units).
+      // Replacing two spaces with the emoji nets +0 codepoints but the .length
+      // delta is +0 for the emoji itself swapping in for a space — adjust to
+      // measure the inserted character cleanly.
+      const baseline = formatProposalBody(
+        "---\n[fm]\n---\n## QIP1: x\n\nHello world\n",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        undefined
+      );
+      const baselinePlusEmoji = formatProposalBody(
+        "---\n[fm]\n---\n## QIP1: x\n\nHello🎉world\n",
+        { chain: "Polygon", author: "a", created: "2026-05-21" },
+        undefined
+      );
+      // Replace single ASCII space with 🎉: ASCII space = 1 code unit,
+      // 🎉 = 2 code units (surrogate pair) → net +1.
+      expect(baselinePlusEmoji.length - baseline.length).toBe(1);
+      // And ensure the encoded length differs from the codepoint count —
+      // proves the function returns a UTF-16-counted string (what Snapshot uses).
+      expect(baselinePlusEmoji.length).not.toBe(Array.from(baselinePlusEmoji).length);
+      // Reference the original variables so the test still uses them.
+      expect(withEmoji.length).toBeGreaterThan(withoutEmoji.length);
+    });
+  });
+});

--- a/src/utils/snapshotPayload.ts
+++ b/src/utils/snapshotPayload.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared serializer for the Snapshot proposal `body` field.
+ *
+ * Single source of truth for both the wire payload (used by `SnapshotSubmitter`
+ * at submission time) and the live character counter (used by the editor and
+ * submitter UIs). Counter and gate call sites measure `formatProposalBody(...).length`
+ * directly — `.length` (UTF-16 code units) is what the Snapshot Sequencer
+ * itself checks (`msg.payload.body.length`), so this matches the server.
+ *
+ * Do NOT count UTF-8 bytes here. The comments backend in mai-api gates on
+ * bytes (see `CommentComposer.tsx`), but Snapshot gates on `.length` —
+ * this is a deliberate per-backend divergence.
+ */
+export function formatProposalBody(
+  rawMarkdown: string,
+  frontmatter: any,
+  transactions?: string | string[]
+): string {
+  // Remove frontmatter from the beginning of the markdown
+  let content = rawMarkdown.replace(/^---[\s\S]*?---\n?/, "").trim();
+
+  // Remove title if it appears at the beginning of the content
+  // This handles various title formats like "## QIP247 Title" or "## **QIP247 Title**"
+  content = content.replace(/^##\s*\*?\*?QIP\d+[:\s].*?\*?\*?\n+/i, "");
+
+  // Build YAML frontmatter for the proposal body
+  const yamlFields = [];
+  yamlFields.push("---");
+
+  // Use "network" instead of "chain"
+  if (frontmatter.chain) {
+    yamlFields.push(`network: ${frontmatter.chain}`);
+  }
+
+  if (frontmatter.author) {
+    yamlFields.push(`author: ${frontmatter.author}`);
+  }
+
+  // Only include implementor if it's not "None"
+  if (frontmatter.implementor && frontmatter.implementor !== "None") {
+    yamlFields.push(`implementor: ${frontmatter.implementor}`);
+  }
+
+  // Only include implementation-date if it's not "None"
+  if (frontmatter["implementation-date"] && frontmatter["implementation-date"] !== "None") {
+    yamlFields.push(`implementation-date: ${frontmatter["implementation-date"]}`);
+  }
+
+  if (frontmatter.created) {
+    yamlFields.push(`created: ${frontmatter.created}`);
+  }
+
+  yamlFields.push("---");
+
+  // Build the full body with YAML frontmatter
+  let fullBody = yamlFields.join("\n") + "\n\n" + content;
+
+  // Add transactions if present - now supporting multisig-grouped format
+  if (transactions) {
+    fullBody += "\n\n## Transactions\n\n";
+
+    try {
+      let parsed: any;
+
+      // Handle both string (new) and string[] (old) formats
+      if (typeof transactions === "string") {
+        // New format: direct string
+        parsed = JSON.parse(transactions);
+      } else if (Array.isArray(transactions) && transactions.length > 0) {
+        // Old format: string array
+        parsed = JSON.parse(transactions[0]);
+      } else {
+        // Invalid format
+        parsed = [];
+      }
+
+      // Check if it's the new multisig-grouped format
+      if (Array.isArray(parsed) && parsed.length > 0 && "multisig" in parsed[0] && "transactions" in parsed[0]) {
+        // New format: group by multisig
+        parsed.forEach((group: any, groupIndex: number) => {
+          if (group.multisig) {
+            fullBody += `### Multisig: \`${group.multisig}\`\n\n`;
+          }
+
+          group.transactions.forEach((tx: any, txIndex: number) => {
+            const txNum = groupIndex > 0 ? `${groupIndex + 1}.${txIndex + 1}` : `${txIndex + 1}`;
+            fullBody += `**Transaction ${txNum}**`;
+
+            // Add annotation if present
+            if (tx.annotation) {
+              fullBody += `\n\n*${tx.annotation}*`;
+            }
+
+            fullBody += `\n\n\`\`\`json\n${JSON.stringify(tx, null, 2)}\n\`\`\`\n\n`;
+          });
+        });
+      } else if (Array.isArray(parsed)) {
+        // Legacy format: simple array of transactions
+        parsed.forEach((tx: any, index: number) => {
+          fullBody += `### Transaction ${index + 1}\n\`\`\`json\n${JSON.stringify(tx, null, 2)}\n\`\`\`\n\n`;
+        });
+      }
+    } catch (error) {
+      // Fallback: treat as legacy format string array
+      if (Array.isArray(transactions)) {
+        transactions.forEach((tx, index) => {
+          fullBody += `### Transaction ${index + 1}\n\`\`\`\n${tx}\n\`\`\`\n\n`;
+        });
+      }
+    }
+  }
+
+  return fullBody;
+}

--- a/src/utils/snapshotPayload.ts
+++ b/src/utils/snapshotPayload.ts
@@ -1,15 +1,8 @@
 /**
- * Shared serializer for the Snapshot proposal `body` field.
- *
- * Single source of truth for both the wire payload (used by `SnapshotSubmitter`
- * at submission time) and the live character counter (used by the editor and
- * submitter UIs). Counter and gate call sites measure `formatProposalBody(...).length`
- * directly — `.length` (UTF-16 code units) is what the Snapshot Sequencer
- * itself checks (`msg.payload.body.length`), so this matches the server.
- *
- * Do NOT count UTF-8 bytes here. The comments backend in mai-api gates on
- * bytes (see `CommentComposer.tsx`), but Snapshot gates on `.length` —
- * this is a deliberate per-backend divergence.
+ * Counter and gate call sites measure `.length` (UTF-16 code units) — what
+ * the Snapshot Sequencer itself checks (`msg.payload.body.length`). Do NOT
+ * swap to UTF-8 bytes; the comments backend (`CommentComposer.tsx`) gates on
+ * bytes but Snapshot doesn't, and a per-backend divergence is intentional.
  */
 export function formatProposalBody(
   rawMarkdown: string,

--- a/src/utils/transactionParser.ts
+++ b/src/utils/transactionParser.ts
@@ -113,19 +113,7 @@ export function parseTransactionsFromContent(content: string): TransactionData[]
 }
 
 /**
- * Serialize an array of TransactionData[] into the JSON string shape that
- * downstream consumers expect — both `IPFSService.formatQCIContent` (at QCI
- * save time) and `formatProposalBody` (at Snapshot submission, and again from
- * the live counter in ProposalEditor + SnapshotSubmitter).
- *
- * Three call sites share this one transformation so the editor's projected
- * character count, the on-IPFS pinned content, and the Snapshot wire payload
- * all measure the same byte sequence. This is the transactions-side mirror of
- * the single-shared-serializer Key Technical Decision in the QIPs char-limit
- * plan; past parallel-read-path bugs in this codebase trace back to two
- * paths that serialized "the same" data slightly differently and drifted.
- *
- * Returns `undefined` for an empty array so consumers can pass the result
+ * Returns `undefined` for an empty array so callers can pass the result
  * straight to `formatProposalBody(rawMarkdown, frontmatter, ?)` without
  * branching on the length themselves.
  */

--- a/src/utils/transactionParser.ts
+++ b/src/utils/transactionParser.ts
@@ -113,6 +113,39 @@ export function parseTransactionsFromContent(content: string): TransactionData[]
 }
 
 /**
+ * Serialize an array of TransactionData[] into the JSON string shape that
+ * downstream consumers expect — both `IPFSService.formatQCIContent` (at QCI
+ * save time) and `formatProposalBody` (at Snapshot submission, and again from
+ * the live counter in ProposalEditor + SnapshotSubmitter).
+ *
+ * Three call sites share this one transformation so the editor's projected
+ * character count, the on-IPFS pinned content, and the Snapshot wire payload
+ * all measure the same byte sequence. This is the transactions-side mirror of
+ * the single-shared-serializer Key Technical Decision in the QIPs char-limit
+ * plan; past parallel-read-path bugs in this codebase trace back to two
+ * paths that serialized "the same" data slightly differently and drifted.
+ *
+ * Returns `undefined` for an empty array so consumers can pass the result
+ * straight to `formatProposalBody(rawMarkdown, frontmatter, ?)` without
+ * branching on the length themselves.
+ */
+export function serializeTransactionsForBody(transactions: TransactionData[]): string | undefined {
+  if (transactions.length === 0) {
+    return undefined;
+  }
+
+  const transactionGroups = groupTransactionsByMultisig(transactions).map((group) => ({
+    multisig: group.multisig,
+    transactions: group.transactions.map((tx) => {
+      const formatted = ABIParser.formatTransaction(tx);
+      return JSON.parse(formatted);
+    }),
+  }));
+
+  return JSON.stringify(transactionGroups, null, 2);
+}
+
+/**
  * Group transactions by multisig address for storage/display
  * This is used when creating or updating QCIs
  */


### PR DESCRIPTION
## Summary

Snapshot's Sequencer rejects proposals with `msg.payload.body` over 10,000 characters (verified-bucket constraint for spaces like `qidao.eth`; turbo bucket is 50k). Without a client gate, oversized submissions fail server-side AFTER the user has signed — a confusing UX where the wallet succeeds but the proposal vanishes.

This PR adds a complete gate:

- **Hard pre-signature block** in `SnapshotSubmitter` when the projected body exceeds the limit
- **Live counter + breakdown tooltip** on the submit form showing markdown, frontmatter, and transactions contributions
- **Advisory counter on the editor** (`ProposalEditor`) so users see remaining budget while writing, not just at submit time
- **Structured server-error remediation**: if the Sequencer rejects anyway (e.g., the limit changes upstream), the catch path classifies against the actual wire-body length and surfaces a "trim by N characters" message instead of a generic failure
- **Shared `formatProposalBody` util** (`src/utils/snapshotPayload.ts`) so submitter and editor compute byte-identical body strings — no drift between the counter and what actually ships

The transactions character cost is now part of the budget. Previously this was a hidden cost — an 8k markdown body could submit fine until a multi-tx group pushed it past 10k post-formatting.

## Test plan

- [x] Unit tests for `formatProposalBody` (12 fixtures: happy path, multisig transactions, legacy string-array transactions, non-ASCII frontmatter, title stripping, body-length measurement)
- [x] `bun run typecheck` clean, vitest suite green
- [ ] Smoke: editor advisory counter increments correctly as body grows and as transactions are added
- [ ] Smoke: writing a body over 10k disables the submit button with the body-too-long error
- [ ] Smoke: simulated server-side rejection (e.g., env-lowered limit via `VITE_SNAPSHOT_BODY_LIMIT_DEFAULT`) shows targeted remediation